### PR TITLE
Remove redundant defer attribute from trust script

### DIFF
--- a/src/scripts/nav.js
+++ b/src/scripts/nav.js
@@ -6,7 +6,6 @@ export function loadTrustIndex() {
   const script = document.createElement('script');
   script.src = 'https://cdn.trustindex.io/loader.js?f82e0f551228447e6c06f9b86c7';
   script.async = true;
-  script.defer = true;
   document.head.appendChild(script);
 }
 


### PR DESCRIPTION
## Summary
- remove the redundant `defer` attribute from the dynamically loaded TrustIndex script so it only loads asynchronously

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68c9457a1b288331ae42b051da800b05