### PR TITLE
Fix navigation toggle loading and accessibility

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,8 +19,15 @@
         <li><a href="/index.html">Home</a></li>
         <li><a href="/rics-home-surveys.html">RICS Home Surveys</a></li>
       </ul>
-      <button class="nav-toggle" aria-label="More" aria-expanded="false">More</button>
-      <ul class="nav-links">
+      <button
+        class="nav-toggle"
+        aria-label="More"
+        aria-controls="secondary-navigation"
+        aria-expanded="false"
+      >
+        More
+      </button>
+      <ul id="secondary-navigation" class="nav-links" hidden>
         <li><a href="/services.html">Services</a></li>
         <li><a href="/local-surveys.html">Areas We Cover</a></li>
         <li><a href="/comparison.html">Pricing</a></li>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -48,6 +48,6 @@ import navScriptUrl from '../scripts/nav.js?url';
       <slot />
     </div>
     <Footer />
-    <script src={navScriptUrl} defer is:inline></script>
+    <script type="module" src={navScriptUrl} defer></script>
   </body>
 </html>

--- a/src/scripts/nav.js
+++ b/src/scripts/nav.js
@@ -14,6 +14,9 @@ export function toggleNav(navToggle, navLinks) {
   const isOpen = navLinks.classList.toggle('nav-open');
   navToggle.classList.toggle('open', isOpen);
   navToggle.setAttribute('aria-expanded', String(isOpen));
+  if (typeof navLinks.toggleAttribute === 'function') {
+    navLinks.toggleAttribute('hidden', !isOpen);
+  }
   return isOpen;
 }
 
@@ -22,6 +25,9 @@ export function setupNav() {
   const navToggle = document.querySelector('.nav-toggle');
   const navLinks = document.querySelector('.nav-links');
   if (navToggle && navLinks) {
+    if (typeof navLinks.toggleAttribute === 'function') {
+      navLinks.toggleAttribute('hidden', !navLinks.classList.contains('nav-open'));
+    }
     navToggle.addEventListener('click', () => {
       toggleNav(navToggle, navLinks);
     });

--- a/tests/nav.test.ts
+++ b/tests/nav.test.ts
@@ -6,10 +6,10 @@ beforeEach(() => {
   vi.resetModules();
   document.head.innerHTML = '';
   document.body.innerHTML = `
-    <button class="nav-toggle" aria-expanded="false"></button>
-    <div class="nav-links">
+    <button class="nav-toggle" aria-controls="secondary-navigation" aria-expanded="false"></button>
+    <ul class="nav-links" hidden>
       <a href="/index.html">Home</a>
-    </div>
+    </ul>
   `;
 });
 
@@ -25,12 +25,14 @@ test('toggles navigation classes on click', async () => {
   expect(navLinks?.classList.contains('nav-open')).toBe(true);
   expect(navToggle?.classList.contains('open')).toBe(true);
   expect(navToggle?.getAttribute('aria-expanded')).toBe('true');
+  expect(navLinks?.hasAttribute('hidden')).toBe(false);
 
   const closed = navModule.toggleNav(navToggle!, navLinks!);
   expect(closed).toBe(false);
   expect(navLinks?.classList.contains('nav-open')).toBe(false);
   expect(navToggle?.classList.contains('open')).toBe(false);
   expect(navToggle?.getAttribute('aria-expanded')).toBe('false');
+  expect(navLinks?.hasAttribute('hidden')).toBe(true);
 });
 
 test('loadTrustIndex injects script once', async () => {
@@ -41,3 +43,4 @@ test('loadTrustIndex injects script once', async () => {
   const scripts = document.querySelectorAll('script[src^="https://cdn.trustindex.io/loader.js"]');
   expect(scripts).toHaveLength(1);
 });
+


### PR DESCRIPTION
## Summary
- ensure the shared navigation script is loaded as a module so the header toggle executes on every page
- improve header markup with aria attributes and a default hidden state for the secondary navigation list
- keep the toggle script in sync with the hidden attribute and extend the navigation unit test to cover the new behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68c952d16a848331879867f4cb6a5eac