### PR TITLE
Add accessibility attributes to header navigation toggle

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,8 +19,16 @@
         <li><a href="/index.html">Home</a></li>
         <li><a href="/rics-home-surveys.html">RICS Home Surveys</a></li>
       </ul>
-      <button class="nav-toggle" aria-label="More" aria-expanded="false">More</button>
-      <ul class="nav-links">
+      <button
+        class="nav-toggle"
+        type="button"
+        aria-label="More"
+        aria-expanded="false"
+        aria-controls="nav-links"
+      >
+        More
+      </button>
+      <ul class="nav-links" id="nav-links">
         <li><a href="/services.html">Services</a></li>
         <li><a href="/local-surveys.html">Areas We Cover</a></li>
         <li><a href="/comparison.html">Pricing</a></li>


### PR DESCRIPTION
## Summary
- add type and aria-controls attributes to the header navigation toggle button
- give the navigation links list an id to match the aria-controls reference

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68c956e140808331b701ebb2e516916e