### PR TITLE
Normalize nav paths for aria-current highlighting

### DIFF
--- a/src/scripts/nav.js
+++ b/src/scripts/nav.js
@@ -1,3 +1,14 @@
+function normalizePathname(pathname) {
+  if (!pathname) return '';
+  let normalized = pathname.startsWith('/') ? pathname : `/${pathname}`;
+  normalized = normalized.replace(/\/index\.html$/, '/');
+  normalized = normalized.replace(/\.html$/, '');
+  if (normalized.length > 1 && normalized.endsWith('/')) {
+    normalized = normalized.slice(0, -1);
+  }
+  return normalized || '/';
+}
+
 export function loadTrustIndex() {
   if (typeof document === 'undefined') return;
   if (document.querySelector('script[src^="https://cdn.trustindex.io/loader.js"]')) {
@@ -27,15 +38,22 @@ export function setupNav() {
     });
   }
 
-  const path = typeof window !== 'undefined' ? window.location.pathname : '';
-  if (path) {
-    document.querySelectorAll('.main-nav a').forEach((link) => {
-      const href = link.getAttribute('href');
-      if (!href) return;
-      if (href === path || (path === '/' && href === '/index.html')) {
-        link.setAttribute('aria-current', 'page');
-      }
-    });
+  if (typeof window !== 'undefined') {
+    const currentPath = normalizePathname(
+      new URL(window.location.pathname, window.location.origin).pathname,
+    );
+    if (currentPath) {
+      document.querySelectorAll('.main-nav a').forEach((link) => {
+        const href = link.getAttribute('href');
+        if (!href) return;
+        const linkPath = normalizePathname(
+          new URL(href, window.location.origin).pathname,
+        );
+        if (linkPath && linkPath === currentPath) {
+          link.setAttribute('aria-current', 'page');
+        }
+      });
+    }
   }
 }
 

--- a/tests/nav.test.ts
+++ b/tests/nav.test.ts
@@ -11,6 +11,7 @@ beforeEach(() => {
       <a href="/index.html">Home</a>
     </div>
   `;
+  window.history.pushState({}, '', '/');
 });
 
 test('toggles navigation classes on click', async () => {
@@ -40,4 +41,44 @@ test('loadTrustIndex injects script once', async () => {
 
   const scripts = document.querySelectorAll('script[src^="https://cdn.trustindex.io/loader.js"]');
   expect(scripts).toHaveLength(1);
+});
+
+test('highlights .html link when current path is extensionless', async () => {
+  document.body.innerHTML = `
+    <button class="nav-toggle" aria-expanded="false"></button>
+    <div class="nav-links">
+      <a href="/index.html">Home</a>
+    </div>
+    <nav class="main-nav">
+      <a href="/services.html" class="services-link">Services</a>
+    </nav>
+  `;
+  window.history.pushState({}, '', '/services');
+
+  const navModule = await import(NAV_MODULE_PATH);
+  const link = document.querySelector<HTMLAnchorElement>('.services-link');
+  expect(link).not.toBeNull();
+  navModule.setupNav();
+
+  expect(link?.getAttribute('aria-current')).toBe('page');
+});
+
+test('highlights extensionless link when current path includes extension', async () => {
+  document.body.innerHTML = `
+    <button class="nav-toggle" aria-expanded="false"></button>
+    <div class="nav-links">
+      <a href="/index.html">Home</a>
+    </div>
+    <nav class="main-nav">
+      <a href="/services" class="services-link">Services</a>
+    </nav>
+  `;
+  window.history.pushState({}, '', '/services.html');
+
+  const navModule = await import(NAV_MODULE_PATH);
+  const link = document.querySelector<HTMLAnchorElement>('.services-link');
+  expect(link).not.toBeNull();
+  navModule.setupNav();
+
+  expect(link?.getAttribute('aria-current')).toBe('page');
 });


### PR DESCRIPTION
## Summary
- normalize current path and nav link URLs before comparing
- treat `.html` and extensionless routes as equivalent when selecting the current link
- add Vitest coverage for both `.html` and extensionless navigation highlighting

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68c956e728908331b4177a1aa4e66337