### PR TITLE
Revamp site styling with refreshed palette and hero design

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1,94 +1,170 @@
 /*──────────────────────────────────────────────
   1. ROOT VARIABLES & BASE RESET
 ──────────────────────────────────────────────*/
+html {
+  scroll-behavior: smooth;
+}
+
 :root {
-  --primary-blue:   #22314A;   /* header/footer/nav - deep navy */
-  --accent-blue:    #1976D2;   /* action buttons/links */
-  --hover-blue:     #1565C0;   /* button hover, focus */
-  --soft-bg:        #F7F9FB;   /* page background */
-  --card-bg:        #fff;      /* cards and content blocks */
-  --divider-grey:   #E5EAF2;   /* borders/dividers */
-  --text-main:      #232F3E;   /* main text */
-  --text-light:     #516075;   /* secondary text */
-  --border-radius:  10px;
-  --shadow:         0 2px 12px rgba(34,49,74,0.07);
+  --primary-blue: #0f172a;
+  --primary-blue-soft: #15264f;
+  --accent-blue: #2563eb;
+  --hover-blue: #1d4ed8;
+  --cta-gold: #fbbf24;
+  --cta-gold-hover: #f59e0b;
+  --soft-bg: #f5f7fb;
+  --card-bg: #ffffff;
+  --divider-grey: #e6ecf7;
+  --text-main: #1f2937;
+  --text-light: #5b6478;
+  --border-radius: 14px;
+  --shadow: 0 18px 45px rgba(15, 23, 42, 0.08);
+  --shadow-soft: 0 8px 22px rgba(15, 23, 42, 0.06);
+  --heading-font: 'Merriweather', 'Georgia', serif;
+  --body-font: 'Open Sans', 'Segoe UI', sans-serif;
 }
 *, *::before, *::after {
   margin: 0; padding: 0; box-sizing: border-box;
 }
 body {
-  font-family: Arial, Helvetica, sans-serif;
-  background: var(--soft-bg);
+  font-family: var(--body-font);
+  background: linear-gradient(
+    180deg,
+    rgba(245, 247, 251, 0.96) 0%,
+    #ffffff 40%,
+    rgba(232, 240, 255, 0.7) 100%
+  );
   color: var(--text-main);
-  line-height: 1.6;
+  line-height: 1.7;
+  min-height: 100vh;
   padding-bottom: 80px;
   transition: background .3s, color .3s;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+::selection {
+  background: rgba(37, 99, 235, 0.15);
+  color: var(--primary-blue);
+}
+
+a {
+  color: var(--accent-blue);
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 0.15em;
+  transition: color .2s ease, text-decoration-color .2s ease;
+}
+
+a:hover {
+  color: var(--hover-blue);
+  text-decoration-color: currentColor;
 }
 
 .skip-link {
   position: absolute;
   left: -1000px;
   top: 1rem;
-  background: var(--primary-blue);
+  background: var(--accent-blue);
   color: #fff;
   padding: 0.5rem 1rem;
-  border-radius: 4px;
+  border-radius: 999px;
   z-index: 2000;
   text-decoration: none;
+  font-weight: 600;
+  box-shadow: var(--shadow-soft);
 }
 
 .skip-link:focus {
   left: 1rem;
 }
-img, svg { max-width: 100%; }
+img, svg {
+  max-width: 100%;
+  display: block;
+}
 
 /*──────────────────────────────────────────────
   2. HEADER & NAVIGATION
 ──────────────────────────────────────────────*/
 header {
-  background: var(--primary-blue);
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.97), rgba(21, 38, 79, 0.97));
   color: #fff;
-  position: sticky; top: 0; z-index: 1000;
-  box-shadow: var(--shadow);
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 .header-inner {
-  display: flex; flex-direction: column;
-  align-items: center; padding: 1rem .5rem;
+  width: min(1200px, 100%);
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1rem 1.5rem;
+  flex-wrap: wrap;
 }
 .branding {
-  display: flex; align-items: center; justify-content: center;
-  margin-bottom: .5rem;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.75rem;
+  margin-bottom: 0;
 }
-.logo-link { display: flex; align-items: center; gap: .5rem; }
-.logo { max-height: 60px; width: auto; }
+.logo-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  text-decoration: none;
+}
+.logo {
+  max-height: 60px;
+  width: auto;
+  filter: drop-shadow(0 10px 18px rgba(15, 23, 42, 0.25));
+}
 .site-name {
-  font-size: 1.2rem; font-weight: bold; color: #fff;
-  line-height: 1; margin-top: -.2rem;
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: #fff;
+  line-height: 1.05;
+  letter-spacing: 0.03em;
+  font-family: var(--heading-font);
+  text-transform: uppercase;
 }
 .main-nav {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 1.5rem;
   position: relative;
+  flex-wrap: wrap;
 }
 .primary-links {
-  list-style: none; display: flex; gap: 1rem;
-  flex-wrap: wrap; justify-content: center;
+  list-style: none;
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
 }
 
 .nav-links {
   list-style: none;
   position: absolute;
-  right: 1rem;
-  top: 100%;
+  right: 1.5rem;
+  top: calc(100% + 1rem);
   display: none;
-  background: var(--primary-blue);
+  background: rgba(15, 23, 42, 0.97);
   color: #fff;
-  padding: 1.5rem;
-  border-radius: 1rem;
-  box-shadow: var(--shadow);
-  min-width: 220px;
+  padding: 1.75rem;
+  border-radius: 1.2rem;
+  box-shadow: 0 28px 55px rgba(15, 23, 42, 0.28);
+  min-width: 230px;
   z-index: 1100;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(14px);
 }
 
 .nav-links.nav-open {
@@ -97,106 +173,230 @@ header {
   gap: 1rem;
 }
 .nav-links a {
-  font-size: 1.1rem;
-  letter-spacing: 0.01em;
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
   display: block;
   line-height: 1.4;
+  text-transform: uppercase;
+  font-weight: 600;
 }
 .main-nav a {
-  color: #fff; text-decoration: none; font-weight: bold;
-  padding: 7px 13px; border-radius: 6px;
-  transition: background .2s;
-  font-size: 1rem;
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  transition: color .2s ease, background .2s ease, transform .18s ease;
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
-.main-nav li a:hover { background: var(--hover-blue); }
+.main-nav li a:hover,
+.main-nav li a:focus-visible {
+  background: rgba(255, 255, 255, 0.15);
+  color: #fff;
+}
 .main-nav a.cta {
-  background: var(--accent-blue); color: #fff;
+  background: linear-gradient(135deg, var(--cta-gold), var(--cta-gold-hover));
+  color: var(--primary-blue);
+  box-shadow: 0 18px 38px rgba(249, 191, 36, 0.35);
 }
-.main-nav a.cta:hover { background: var(--hover-blue); }
-header .main-nav a.cta {
-  background-color: var(--accent-blue) !important;
-  color: #fff !important;
-}
-header .main-nav a.cta:hover {
-  background-color: var(--hover-blue) !important;
+.main-nav a.cta:hover,
+.main-nav a.cta:focus-visible {
+  background: linear-gradient(135deg, var(--cta-gold-hover), var(--cta-gold));
+  color: var(--primary-blue);
 }
 .main-nav a[aria-current="page"] {
-  border-bottom: 2px solid #fff;
+  background: rgba(255, 255, 255, 0.18);
+  color: #fff;
+}
+.nav-toggle {
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  color: #fff;
+  font-weight: 700;
+  padding: 0.55rem 1.15rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background .2s ease, color .2s ease, transform .18s ease;
+}
+
+.nav-toggle:hover,
+.nav-toggle.open {
+  background: rgba(255, 255, 255, 0.22);
+  color: #fff;
 }
 
 /*──────────────────────────────────────────────
   3. FOOTER
 ──────────────────────────────────────────────*/
 .site-footer {
-  background: var(--primary-blue); color: #fff; font-size: .97rem;
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.98), rgba(21, 38, 79, 0.98) 65%, rgba(37, 99, 235, 0.6));
+  color: #fff;
+  font-size: .97rem;
+  padding: 2.5rem 0 0;
+  position: relative;
+  overflow: hidden;
+}
+.site-footer::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top left, rgba(59, 130, 246, 0.35), transparent 55%);
+  opacity: 0.9;
+  pointer-events: none;
+}
+.site-footer > * {
+  position: relative;
+  z-index: 1;
 }
 .site-footer .footer-top {
-  display: flex; flex-wrap: wrap; gap: 2rem;
-  max-width: 1200px; margin: 0 auto; padding: 2rem 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: clamp(1.5rem, 6vw, 3rem);
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 2rem;
 }
-.site-footer .footer-col { flex: 1 1 200px; }
+.site-footer .footer-col {
+  flex: 1 1 220px;
+  min-width: 210px;
+}
 .site-footer .footer-col h3 {
-  font-size: 1.1rem; margin-bottom: .5rem; color: #fff;
+  font-size: 1.1rem;
+  margin-bottom: .75rem;
+  color: #fff;
+  font-family: var(--heading-font);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 .site-footer .footer-col a {
-  color: var(--accent-blue); text-decoration: none;
+  color: rgba(255, 255, 255, 0.85);
+  text-decoration: none;
+  transition: color .2s ease, transform .2s ease;
 }
-.site-footer .footer-col a:hover { text-decoration: underline; }
+.site-footer .footer-col a:hover {
+  color: #fff;
+  transform: translateX(4px);
+}
 .site-footer .footer-links {
-  list-style: none; padding: 0; display: grid; gap: .4rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: .4rem;
 }
 .site-footer .footer-links a {
-  color: var(--divider-grey);
+  color: rgba(255, 255, 255, 0.75);
 }
-.site-footer .footer-links a:hover { color: #fff; }
+.site-footer .footer-links a:hover {
+  color: #fff;
+}
 .site-footer .footer-logos img {
   margin: .5rem .5rem 0 0;
+  filter: drop-shadow(0 12px 22px rgba(0, 0, 0, 0.25));
 }
 .site-footer .footer-cta {
-  background: var(--accent-blue); text-align: center; padding: 1rem;
+  background: linear-gradient(135deg, var(--cta-gold), var(--cta-gold-hover));
+  text-align: center;
+  padding: 1.5rem;
+  border-radius: 18px;
+  max-width: 420px;
+  margin: 0 auto 2.5rem;
+  box-shadow: 0 26px 45px rgba(249, 191, 36, 0.32);
 }
 .site-footer .footer-cta .cta-button {
-  background: #fff; color: var(--accent-blue);
-  font-weight: 600; padding: .6rem 1.2rem; border-radius: 6px;
-  text-decoration: none; transition: background .2s;
-  margin: .5rem auto 0 auto;
+  background: #fff;
+  color: var(--primary-blue);
+  font-weight: 700;
+  padding: .8rem 1.6rem;
+  border-radius: 999px;
+  text-decoration: none;
+  transition: background .2s ease, color .2s ease, transform .18s ease;
+  margin: .75rem auto 0 auto;
+  display: inline-block;
 }
 .site-footer .footer-cta .cta-button:hover {
-  background: var(--divider-grey);
+  background: rgba(255, 255, 255, 0.85);
+  transform: translateY(-2px);
 }
 .site-footer .footer-bottom {
-  background: var(--hover-blue); padding: .75rem 1rem;
-  text-align: center; font-size: .85rem; color: #ddd;
+  background: rgba(15, 23, 42, 0.85);
+  padding: 1rem 1rem;
+  text-align: center;
+  font-size: .85rem;
+  color: rgba(255, 255, 255, 0.72);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
 .site-footer .footer-bottom a {
-  color: #fff; text-decoration: none;
+  color: #fff;
+  text-decoration: none;
 }
-.site-footer .footer-bottom a:hover { text-decoration: underline; }
+.site-footer .footer-bottom a:hover {
+  text-decoration: underline;
+}
 @media (max-width: 600px) {
-  .site-footer .footer-top { flex-direction: column; text-align: center; }
+  .site-footer .footer-top {
+    flex-direction: column;
+    text-align: center;
+    align-items: center;
+  }
+  .site-footer .footer-col {
+    max-width: 320px;
+  }
 }
 
 /*──────────────────────────────────────────────
   4. TYPOGRAPHY & SECTIONS
 ──────────────────────────────────────────────*/
-h1,h2,h3,h4,h5,h6 {
-  margin-bottom: 1rem; font-family: inherit;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin-bottom: 1rem;
+  font-family: var(--heading-font);
+  color: var(--primary-blue);
+  line-height: 1.25;
+  text-wrap: balance;
 }
-h1 { font-size: 2.2rem; }
-h2 { font-size: 1.5rem; }
-h3 { font-size: 1.15rem; }
-p, ul, ol, blockquote, table {
-  margin-bottom: 1.3rem; line-height: 1.6;
+h1 { font-size: clamp(2.35rem, 5vw, 2.9rem); }
+h2 { font-size: clamp(1.75rem, 4vw, 2.2rem); }
+h3 { font-size: clamp(1.25rem, 3vw, 1.5rem); }
+p,
+ul,
+ol,
+blockquote,
+table {
+  margin-bottom: 1.35rem;
+  line-height: 1.7;
+  color: var(--text-main);
+}
+p.lead,
+.section-lead {
+  font-size: 1.1rem;
+  color: var(--text-light);
+}
+main {
+  display: grid;
+  gap: clamp(2.5rem, 6vw, 4rem);
 }
 section {
-  padding: 3.5rem 1rem;
+  padding: clamp(2.8rem, 6vw, 4rem) 1.2rem;
 }
 section > .box-container {
-  background: var(--card-bg);
-  max-width: 1150px; margin: 0 auto;
-  padding: 2.2rem 1.4rem; border-radius: var(--border-radius);
-  box-shadow: var(--shadow);
-  border: 1px solid var(--divider-grey);
+  background: rgba(255, 255, 255, 0.92);
+  max-width: 1150px;
+  margin: 0 auto;
+  padding: clamp(2rem, 5vw, 3rem);
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow-soft);
+  border: 1px solid rgba(229, 234, 242, 0.9);
+  backdrop-filter: blur(6px);
+}
+section > .box-container > *:last-child {
+  margin-bottom: 0;
 }
 
 /*──────────────────────────────────────────────
@@ -205,130 +405,225 @@ section > .box-container {
 [class*="grid"] {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(270px,1fr));
-  gap: 2rem; margin: 2rem 0;
+  gap: clamp(1.5rem, 5vw, 2.5rem);
+  margin: 2rem 0;
 }
 [class*="card"], [class*="service"], [class*="survey"] {
-  background: var(--card-bg); padding: 2rem; border-radius: var(--border-radius);
-  box-shadow: var(--shadow);
-  border: 1px solid var(--divider-grey);
-  transition: transform .18s, box-shadow .2s;
+  background: linear-gradient(180deg, #ffffff 0%, rgba(255, 255, 255, 0.92) 100%);
+  padding: clamp(1.8rem, 4vw, 2.4rem);
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow-soft);
+  border: 1px solid rgba(229, 234, 242, 0.9);
+  transition: transform .18s ease, box-shadow .22s ease, border-color .22s ease;
 }
 [class*="card"]:hover,
 [class*="service"]:hover,
 [class*="survey"]:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 6px 20px rgba(34,49,74,0.09);
+  transform: translateY(-4px);
+  box-shadow: var(--shadow);
+  border-color: rgba(37, 99, 235, 0.35);
 }
 
 /*──────────────────────────────────────────────
   6. BUTTONS & LINKS
 ──────────────────────────────────────────────*/
-.cta-button, .hero-contrast, button[type="submit"] {
-  display: inline-block;
-  background: var(--accent-blue); color: #fff;
-  padding: 1rem 2rem; font-weight: 600;
-  border-radius: 30px; text-decoration: none;
+.cta-button,
+.hero-contrast,
+button[type="submit"] {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  background: linear-gradient(135deg, var(--cta-gold), var(--cta-gold-hover));
+  color: var(--primary-blue);
+  padding: 0.85rem 1.9rem;
+  font-weight: 700;
+  border-radius: 999px;
+  text-decoration: none;
   border: none;
-  box-shadow: var(--shadow);
-  transition: background .18s, transform .18s;
-  cursor: pointer; font-size: 1rem;
+  box-shadow: 0 18px 38px rgba(249, 191, 36, 0.32);
+  transition: transform .18s ease, box-shadow .2s ease, background .2s ease;
+  cursor: pointer;
+  font-size: 1rem;
+  letter-spacing: 0.02em;
 }
-.cta-button:hover, .hero-contrast:hover, button[type="submit"]:hover {
-  background: var(--hover-blue); transform: translateY(-2px);
+.cta-button:hover,
+.hero-contrast:hover,
+button[type="submit"]:hover {
+  background: linear-gradient(135deg, var(--cta-gold-hover), var(--cta-gold));
+  transform: translateY(-3px);
+  box-shadow: 0 22px 42px rgba(245, 158, 11, 0.35);
+}
+.cta-button:focus-visible,
+.hero-contrast:focus-visible,
+button[type="submit"]:focus-visible {
+  outline: 3px solid var(--accent-blue);
+  outline-offset: 3px;
 }
 .cta-button.small {
-  padding: .6rem 1.2rem; font-size: .96rem;
+  padding: .65rem 1.3rem;
+  font-size: .95rem;
 }
 .inline-link {
   color: var(--accent-blue);
-  text-decoration: underline;
   font-weight: 600;
+  text-decoration: underline;
 }
-.inline-link:hover { color: var(--hover-blue); }
-a:focus, button:focus, input:focus, select:focus {
-  outline: 2px solid var(--accent-blue); outline-offset: 2px;
+.inline-link:hover {
+  color: var(--hover-blue);
+}
+a:focus,
+button:focus,
+input:focus,
+select:focus,
+textarea:focus {
+  outline: 3px solid var(--accent-blue);
+  outline-offset: 3px;
 }
 
 /*──────────────────────────────────────────────
   7. TABLES
 ──────────────────────────────────────────────*/
 table {
-  width: 100%; border-collapse: collapse; margin: 2rem 0;
-  background: var(--card-bg);
+  width: 100%;
+  border-collapse: collapse;
+  margin: 2rem 0;
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: var(--border-radius);
+  overflow: hidden;
+  box-shadow: var(--shadow-soft);
+  border: 1px solid rgba(229, 234, 242, 0.9);
 }
-th, td {
-  border: 1px solid var(--divider-grey);
-  padding: .75rem 1rem; text-align: center;
+th,
+td {
+  border-bottom: 1px solid rgba(229, 234, 242, 0.9);
+  padding: .85rem 1.1rem;
+  text-align: center;
 }
 thead th {
-  background: var(--primary-blue); color: #fff;
+  background: linear-gradient(135deg, var(--primary-blue), var(--primary-blue-soft));
+  color: #fff;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+tbody tr:nth-child(even) {
+  background: rgba(245, 247, 251, 0.6);
+}
+tbody tr:hover {
+  background: rgba(37, 99, 235, 0.08);
 }
 
 /*──────────────────────────────────────────────
   8. ACCORDIONS
 ──────────────────────────────────────────────*/
 details {
-  background: var(--card-bg); border-radius: 6px; padding: 1rem;
-  margin: 1.2rem 0; box-shadow: var(--shadow);
-  overflow: hidden; transition: max-height .3s;
-  max-height: 2.5rem;
-  border: 1px solid var(--divider-grey);
+  background: rgba(255, 255, 255, 0.94);
+  border-radius: var(--border-radius);
+  padding: 1.1rem 1.25rem;
+  margin: 1.4rem 0;
+  box-shadow: var(--shadow-soft);
+  border: 1px solid rgba(229, 234, 242, 0.9);
+  transition: box-shadow .2s ease, border-color .2s ease;
 }
-details[open] { max-height: 100vh; }
+details[open] {
+  box-shadow: var(--shadow);
+  border-color: rgba(37, 99, 235, 0.28);
+}
 summary {
-  font-weight: 600; cursor: pointer;
+  font-weight: 700;
+  cursor: pointer;
+  color: var(--primary-blue);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
 }
 summary::after {
-  content: "▼"; float: right; transition: transform .2s;
+  content: "\25BC";
+  font-size: 0.85rem;
+  transition: transform .25s ease;
+  color: var(--accent-blue);
 }
-details[open] summary::after { content: "▲"; }
+details[open] summary::after {
+  transform: rotate(180deg);
+}
 
 /*──────────────────────────────────────────────
   9. TABLE OF CONTENTS NAV
 ──────────────────────────────────────────────*/
 .services-toc {
-  background: var(--card-bg); padding: 1rem 1.5rem;
-  margin: 2rem 0; border-radius: 7px;
-  box-shadow: var(--shadow);
-  border: 1px solid var(--divider-grey);
+  background: rgba(255, 255, 255, 0.92);
+  padding: 1.4rem 1.8rem;
+  margin: 2.2rem 0;
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow-soft);
+  border: 1px solid rgba(229, 234, 242, 0.9);
 }
 .services-toc .toc-list {
-  list-style: none; display: flex; flex-wrap: wrap; gap: 1rem;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.25rem;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
 }
 .services-toc a {
-  font-weight: 600; color: var(--accent-blue);
+  font-weight: 700;
+  color: var(--accent-blue);
   text-decoration: none;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  transition: background .2s ease, color .2s ease;
 }
-.services-toc a:hover { text-decoration: underline; }
+.services-toc a:hover {
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--hover-blue);
+}
 
 /*──────────────────────────────────────────────
   10. PROCESS TIMELINE
 ──────────────────────────────────────────────*/
 .process-timeline {
-  background: var(--soft-bg); padding: 2.2rem 1rem;
-  margin: 2rem 0; border-radius: var(--border-radius);
+  background: linear-gradient(145deg, rgba(37, 99, 235, 0.08), rgba(251, 191, 36, 0.12));
+  padding: clamp(2rem, 5vw, 2.8rem) 1.5rem;
+  margin: 2rem 0;
+  border-radius: var(--border-radius);
+  border: 1px solid rgba(229, 234, 242, 0.9);
+  box-shadow: var(--shadow-soft);
 }
 .timeline-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(120px,1fr));
-  gap: 2rem; text-align: center;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  text-align: center;
 }
 .timeline-grid svg {
-  stroke: var(--accent-blue); margin-bottom: .5rem;
+  stroke: var(--accent-blue);
+  margin-bottom: .6rem;
+  filter: drop-shadow(0 10px 18px rgba(37, 99, 235, 0.18));
 }
 .timeline-grid p {
-  font-weight: 600; font-size: .97rem;
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--primary-blue);
 }
 
 /*──────────────────────────────────────────────
   11. SERVICE BLOCKS & BULLET LISTS
 ──────────────────────────────────────────────*/
 .service-block {
-  background: var(--card-bg); margin: 2rem 0; padding: 2rem;
-  border-radius: var(--border-radius); box-shadow: var(--shadow);
-  border: 1px solid var(--divider-grey);
+  background: linear-gradient(180deg, #ffffff 0%, rgba(255, 255, 255, 0.9) 100%);
+  margin: 2rem 0;
+  padding: clamp(1.8rem, 4vw, 2.5rem);
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow-soft);
+  border: 1px solid rgba(229, 234, 242, 0.9);
 }
-.service-block.alt { background: var(--soft-bg); }
+.service-block.alt {
+  background: rgba(245, 247, 251, 0.85);
+}
 .bullet-list { list-style: none; padding-left: 0; }
 .bullet-list li {
   position: relative; padding-left: 1.5rem; margin-bottom: .5rem;
@@ -342,110 +637,195 @@ details[open] summary::after { content: "▲"; }
   12. FORMS
 ──────────────────────────────────────────────*/
 form label {
-  display: block; margin-bottom: .5rem; font-weight: 600;
+  display: block;
+  margin-bottom: .5rem;
+  font-weight: 700;
+  color: var(--primary-blue);
 }
-form input, form select, form textarea {
-  width: 100%; padding: .85rem 1rem; margin-bottom: 1.1rem;
-  border: 1px solid var(--divider-grey); border-radius: 7px;
-  font-family: inherit; font-size: 1rem; background: #fff;
-  transition: border .2s;
+form input,
+form select,
+form textarea {
+  width: 100%;
+  padding: .9rem 1rem;
+  margin-bottom: 1.1rem;
+  border: 1px solid rgba(229, 234, 242, 0.9);
+  border-radius: 10px;
+  font-family: var(--body-font);
+  font-size: 1rem;
+  background: rgba(255, 255, 255, 0.95);
+  transition: border-color .2s ease, box-shadow .2s ease;
+  box-shadow: inset 0 2px 6px rgba(15, 23, 42, 0.05);
 }
-form input:focus, form select:focus, form textarea:focus {
+form input:focus,
+form select:focus,
+form textarea:focus {
   border-color: var(--accent-blue);
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.12);
 }
-form button, .quote-form button {
-  padding: 1rem 2rem; border: none; border-radius: 30px;
-  font-weight: 600; background: var(--accent-blue);
-  color: #fff; cursor: pointer; transition: background .2s;
-  box-shadow: var(--shadow);
+form textarea {
+  min-height: 160px;
 }
-form button:hover, .quote-form button:hover {
-  background: var(--hover-blue);
+form button,
+.quote-form button {
+  padding: 0.9rem 1.8rem;
+  border: none;
+  border-radius: 999px;
+  font-weight: 700;
+  background: linear-gradient(135deg, var(--cta-gold), var(--cta-gold-hover));
+  color: var(--primary-blue);
+  cursor: pointer;
+  transition: transform .18s ease, box-shadow .2s ease, background .2s ease;
+  box-shadow: 0 18px 38px rgba(249, 191, 36, 0.32);
+}
+form button:hover,
+.quote-form button:hover {
+  background: linear-gradient(135deg, var(--cta-gold-hover), var(--cta-gold));
+  transform: translateY(-2px);
+  box-shadow: 0 22px 42px rgba(245, 158, 11, 0.35);
 }
 
 /*──────────────────────────────────────────────
   HOME HERO QUOTE FORM
 ──────────────────────────────────────────────*/
 .hero-quote {
-  background: #ECF1EF;
-  padding: 3rem 0 1rem;
+  background: linear-gradient(160deg, rgba(37, 99, 235, 0.12), rgba(251, 191, 36, 0.18));
+  padding: clamp(3rem, 8vw, 4.2rem) 0 clamp(2rem, 6vw, 3rem);
+  position: relative;
+  overflow: hidden;
+}
+.hero-quote::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 12% 20%, rgba(255, 255, 255, 0.55), transparent 55%);
+  pointer-events: none;
+}
+.hero-quote::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 88% 10%, rgba(37, 99, 235, 0.15), transparent 60%);
+  pointer-events: none;
 }
 
 .hero-quote .hero-container {
-  max-width: 580px;
+  max-width: 620px;
   margin: 0 auto;
+  padding: 0 1.5rem;
+  position: relative;
+  z-index: 1;
+  text-align: center;
 }
 
 .review-badge {
-  text-align: center;
-  margin-bottom: 1.2rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.6rem 1.2rem;
+  margin-bottom: 1.4rem;
+  background: rgba(255, 255, 255, 0.55);
+  border-radius: 999px;
+  color: var(--primary-blue);
+  font-weight: 600;
+  box-shadow: var(--shadow-soft);
 }
 
 .review-badge .stars {
-  color: #FFB300;
+  color: #f59e0b;
   font-size: 1.5rem;
+  letter-spacing: 0.18em;
 }
 
 .review-badge .rating-text {
-  margin-left: .5rem;
-  color: #233038;
+  margin-left: 0;
+  color: var(--primary-blue);
+  letter-spacing: 0.03em;
 }
 
 .hero-quote h1 {
   text-align: center;
-  margin-bottom: .5rem;
+  margin-bottom: .75rem;
 }
 
 .hero-quote > p {
   text-align: center;
-  margin-bottom: 1.5rem;
+  margin: 0 auto 1.85rem;
+  max-width: 46rem;
+  color: var(--text-light);
+  font-size: 1.08rem;
 }
 
 .quote-form {
-  background: #fff;
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0,0,0,.08);
-  padding: 2rem 1.5rem;
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow);
+  padding: clamp(2rem, 5vw, 2.6rem) clamp(1.6rem, 4vw, 2.1rem);
   margin-bottom: 2rem;
+  border: 1px solid rgba(229, 234, 242, 0.9);
+  backdrop-filter: blur(10px);
 }
 
 .quote-form .form-grid {
   display: grid;
-  gap: 1rem;
+  gap: 1.1rem;
 }
 
 .quote-form label {
   display: flex;
   flex-direction: column;
-  gap: .25rem;
+  gap: .35rem;
 }
 
 .quote-form button {
-  margin-top: 1rem;
+  margin-top: 1.15rem;
   width: 100%;
 }
 
 .quote-form ul {
-  list-style: disc inside;
-  margin-top: 1.5rem;
-  color: #233038;
+  list-style: none;
+  margin-top: 1.75rem;
+  color: var(--text-main);
   font-size: 1rem;
   text-align: left;
+  padding-left: 0;
+}
+
+.quote-form ul li {
+  position: relative;
+  padding-left: 1.6rem;
+  margin-bottom: .65rem;
+}
+
+.quote-form ul li::before {
+  content: '\2713';
+  position: absolute;
+  left: 0;
+  top: 0.15rem;
+  color: var(--accent-blue);
+  font-weight: 700;
 }
 
 /*──────────────────────────────────────────────
   13. STICKY CTA
 ──────────────────────────────────────────────*/
 .sticky-cta {
-  position: fixed; bottom: 20px; right: 20px; z-index: 1000;
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 1000;
 }
 .sticky-cta .cta-button {
-  box-shadow: 0 2px 10px rgba(34,49,74,0.18);
-  padding: .95rem 1.7rem;
+  box-shadow: 0 22px 38px rgba(249, 191, 36, 0.4);
+  padding: .95rem 1.8rem;
 }
 @media (max-width: 600px) {
+  .sticky-cta {
+    bottom: 18px;
+    right: 16px;
+  }
   .sticky-cta .cta-button {
-    padding: .75rem 1rem; font-size: .95rem;
+    padding: .75rem 1.3rem;
+    font-size: .95rem;
   }
 }
 
@@ -453,18 +833,29 @@ form button:hover, .quote-form button:hover {
   14. SLIDER (Services)
 ──────────────────────────────────────────────*/
 .service-slider-wrapper {
-  position: relative; margin: 2rem 0;
+  position: relative;
+  margin: 2.5rem 0;
 }
 .service-slider {
-  display: flex; gap: 1rem; overflow-x: auto;
-  scroll-snap-type: x mandatory; -webkit-overflow-scrolling: touch;
-  padding-bottom: 1rem;
+  display: flex;
+  gap: 1.5rem;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  padding: 0 0 1.5rem;
+  scroll-padding: 1.5rem;
 }
-.service-slider .service-card {
-  flex: 0 0 80%; scroll-snap-align: start;
+.service-slider::-webkit-scrollbar {
+  height: 8px;
 }
-.service-slider::-webkit-scrollbar { display: none; }
-.service-slider { -ms-overflow-style: none; scrollbar-width: none; }
+.service-slider::-webkit-scrollbar-thumb {
+  background: rgba(37, 99, 235, 0.25);
+  border-radius: 999px;
+}
+.service-slider {
+  -ms-overflow-style: none;
+  scrollbar-width: thin;
+}
 /*──────────────────────────────────────────────
   15. “AREAS WE COVER” / DROPDOWN SECTION
 ──────────────────────────────────────────────*/
@@ -481,21 +872,27 @@ form button:hover, .quote-form button:hover {
   color: var(--text-light); font-size: 1.1rem; margin-bottom: 2rem;
 }
 .improved-areas .dropdown-card {
-  background: var(--card-bg); border-radius: var(--border-radius);
-  box-shadow: var(--shadow);
-  padding: 1.5rem; position: relative;
-  border: 1px solid var(--divider-grey);
+  background: linear-gradient(180deg, #ffffff 0%, rgba(255, 255, 255, 0.9) 100%);
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow-soft);
+  padding: 1.6rem;
+  position: relative;
+  border: 1px solid rgba(229, 234, 242, 0.9);
 }
 .improved-areas .custom-select { position: relative; }
 .improved-areas select#areaDropdown {
-  width: 100%; padding: .75rem 1rem; font-size: 1rem;
-  border: 1px solid var(--divider-grey); border-radius: 7px;
-  background: #fff; appearance: none;
+  width: 100%;
+  padding: .85rem 1rem;
+  font-size: 1rem;
+  border: 1px solid rgba(229, 234, 242, 0.9);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.95);
+  appearance: none;
   cursor: pointer;
 }
 .improved-areas .chevron {
   position: absolute; top: 50%; right: 1rem;
-  transform: translateY(-50%); font-size: 1.25rem; color: var(--text-light);
+  transform: translateY(-50%); font-size: 1.25rem; color: var(--accent-blue);
   pointer-events: none;
 }
 
@@ -503,38 +900,70 @@ form button:hover, .quote-form button:hover {
   16. TRUST FEATURES (Icons + Headings)
 ──────────────────────────────────────────────*/
 .trust-list {
-  list-style: none; padding: 0; margin: 0 auto;
+  list-style: none;
+  padding: 0;
+  margin: 0 auto;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 1.3rem;
   justify-items: center;
 }
 .trust-list li {
-  background: var(--card-bg);
-  padding: 1.2rem;
+  background: linear-gradient(180deg, #ffffff 0%, rgba(255, 255, 255, 0.9) 100%);
+  padding: clamp(1.3rem, 3vw, 1.8rem);
   border-radius: var(--border-radius);
-  box-shadow: var(--shadow);
+  box-shadow: var(--shadow-soft);
   text-align: center;
-  display: flex; flex-direction: column; align-items: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border: 1px solid rgba(229, 234, 242, 0.9);
 }
 .trust-list svg {
-  color: var(--accent-blue); margin-bottom: .6rem;
+  color: var(--accent-blue);
+  margin-bottom: .6rem;
+  font-size: 2rem;
 }
 
 /*──────────────────────────────────────────────
   17. RESPONSIVE BREAKPOINTS
 ──────────────────────────────────────────────*/
 @media (max-width: 768px) {
-  .header-inner { flex-direction: column; gap: .5rem; }
-  .hero { padding: 2.2rem 1rem; }
-  section { padding: 2rem 1rem; }
-  [class*="grid"] { grid-template-columns: 1fr; }
-  section > .box-container { padding: 1.2rem; }
+  .header-inner {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1.25rem;
+    padding: 1rem 1.1rem;
+  }
+  .branding {
+    justify-content: space-between;
+  }
+  .main-nav {
+    width: 100%;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+  .primary-links {
+    justify-content: flex-start;
+    gap: 1rem;
+  }
+  .hero {
+    padding: 2.2rem 1rem;
+  }
+  section {
+    padding: 2.2rem 1rem;
+  }
+  [class*="grid"] {
+    grid-template-columns: 1fr;
+  }
+  section > .box-container {
+    padding: 1.6rem;
+  }
 }
 
 @media (max-width: 500px) {
-  h1 { font-size: 1.38rem; }
-  h2 { font-size: 1.1rem; }
+  h1 { font-size: 1.95rem; }
+  h2 { font-size: 1.35rem; }
   .comparison-table { font-size: 0.9rem; }
 }
 
@@ -560,39 +989,33 @@ form button:hover, .quote-form button:hover {
   font-size: 2rem;
 }
 
-.service-slider-wrapper {
-  position: relative;
-}
-.service-slider {
-  display: flex;
-  gap: 2rem;
-  overflow-x: auto;
-  scroll-snap-type: x mandatory;
-  -webkit-overflow-scrolling: touch;
-  padding-bottom: 1.5rem;
-}
 .service-slider .service-card {
-  background: var(--card-bg);        /* White card */
-  color: var(--text-main);           /* Main text color */
-  padding: 2rem 1.5rem;
+  flex: 0 0 clamp(280px, 80%, 360px);
+  scroll-snap-align: start;
+  background: linear-gradient(180deg, #ffffff 0%, rgba(255, 255, 255, 0.92) 100%);
+  color: var(--text-main);
+  padding: clamp(1.6rem, 4vw, 2.3rem);
   border-radius: var(--border-radius);
-  min-width: 340px; max-width: 400px; margin: 0 auto;
-  box-shadow: var(--shadow);
+  margin: 0 auto;
+  box-shadow: var(--shadow-soft);
+  border: 1px solid rgba(229, 234, 242, 0.9);
+  transition: transform .18s ease, box-shadow .22s ease, border-color .22s ease;
   text-align: left;
-  scroll-snap-align: center;
-  border: 1px solid var(--divider-grey);
-  transition: box-shadow .18s, border-color .18s;
 }
 .service-slider .service-card:hover {
-  box-shadow: 0 8px 24px rgba(34,49,74,0.18);
-  border-color: var(--accent-blue);
+  transform: translateY(-4px);
+  box-shadow: var(--shadow);
+  border-color: rgba(37, 99, 235, 0.28);
 }
 @media (max-width: 500px) {
-  .service-slider .service-card { min-width: 220px; padding: 1.3rem 1rem;}
+  .service-slider .service-card {
+    min-width: 240px;
+    padding: 1.4rem 1.2rem;
+  }
 }
 
 .stars {
-  color: #ffc43a;                /* Gold for stars */
+  color: #f59e0b;
   font-size: 1.45em;
   font-weight: bold;
   letter-spacing: .13em;
@@ -607,86 +1030,79 @@ form button:hover, .quote-form button:hover {
 }
 
 .slider-arrow {
-  position: absolute; top: 50%; transform: translateY(-50%);
-  background: #ffc43a;           /* Gold arrow */
-  color: var(--primary-blue);    /* Navy icon */
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: linear-gradient(135deg, var(--cta-gold), var(--cta-gold-hover));
+  color: var(--primary-blue);
   border: none;
   font-size: 2.1rem;
-  width: 2.5rem; height: 2.5rem;
+  width: 2.5rem;
+  height: 2.5rem;
   border-radius: 50%;
-  cursor: pointer; z-index: 10; opacity: 0.94;
-  box-shadow: 0 2px 10px rgba(34,49,74,0.12);
-  display: flex; align-items: center; justify-content: center;
-  transition: background .23s, color .23s;
+  cursor: pointer;
+  z-index: 10;
+  opacity: 0.94;
+  box-shadow: 0 22px 38px rgba(249, 191, 36, 0.32);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background .23s, color .23s, transform .18s;
 }
 .slider-arrow.prev { left: .5rem; }
 .slider-arrow.next { right: .5rem; }
+.slider-arrow:hover {
+  background: linear-gradient(135deg, var(--cta-gold-hover), var(--cta-gold));
+}
+
 .slider-arrow:focus {
   outline: 3px solid var(--accent-blue);
   background: var(--primary-blue);
-  color: #ffc43a;
+  color: #fff;
 }
 
 /* Trust / Why Choose grid (mirrors .process-timeline) */
 .trust-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1rem;
+  gap: 1.3rem;
   margin-top: 1rem;
 }
 
 .trust-card {
-  background: #fff;
-  border-radius: 0.5rem;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
-  padding: 1.5rem;
+  background: linear-gradient(180deg, #ffffff 0%, rgba(255, 255, 255, 0.92) 100%);
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow-soft);
+  padding: 1.6rem;
   text-align: center;
   display: flex;
   flex-direction: column;
   align-items: center;
-  /* ensure all cards are same height */
   min-height: 200px;
+  border: 1px solid rgba(229, 234, 242, 0.9);
 }
 
-/* Icon styling (optional) */
 .trust-card svg {
   margin-bottom: 0.75rem;
-  color: var(--primary-color, #1d4ed8);
+  color: var(--accent-blue);
   width: 2rem;
   height: 2rem;
 }
 
-/* Headings & paragraphs inside card */
 .trust-card strong {
   margin-bottom: 0.5rem;
   font-size: 1.1rem;
+  color: var(--primary-blue);
 }
 .trust-card p {
   margin: 0;
-  color: #555;
-  flex-grow: 1; /* push CTA (if any) down */
+  color: var(--text-light);
+  flex-grow: 1;
 }
 
-/* Utility: blue section title */
 .section-title--blue {
-  color: var(--primary-blue);       /* whatever your “blue” variable is */
+  color: var(--primary-blue);
   margin-bottom: 1rem;
-}
-
-/* Make box-container look like your timeline card */
-.box-container {
-  background: #fff;
-  border-radius: 0.5rem;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
-  padding: 2rem;
-  margin-bottom: 2rem;
-}
-
-/* Trust-features grid (already in place) */
-.trust-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px,1fr));
-  gap: 1rem;
 }
 
 /* Centre the jump-to links */
@@ -709,26 +1125,11 @@ form button:hover, .quote-form button:hover {
 .process-timeline .section-title--blue {
   margin-bottom: 1.5rem;
 }
-.nav-toggle {
-  background: none;
-  border: none;
-  color: #fff;
-  font-weight: bold;
-  padding: 7px 13px;
-  border-radius: 6px;
-  cursor: pointer;
-  transition: background .2s;
-}
-
-.nav-toggle:hover,
-.nav-toggle.open {
-  background: var(--hover-blue);
-}
-
 @media (max-width: 700px) {
   .nav-links {
-    left: 1rem;
-    right: 1rem;
-    width: auto;
+    left: 0;
+    right: 0;
+    margin: 0 auto;
+    width: min(90vw, 320px);
   }
 }


### PR DESCRIPTION
## Summary
- refresh the global colour palette, typography, and base link styling for a cleaner, more branded look
- modernise the header, footer, CTA buttons, hero quote section, forms, slider, and trust feature cards
- tweak responsive navigation spacing and sticky CTA visuals for better mobile usability

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68c9701d8ab08323914866161ab48ed9