### PR TITLE
Fix testimonials placeholder removal in legacy parser

### DIFF
--- a/src/utils/legacy.ts
+++ b/src/utils/legacy.ts
@@ -16,6 +16,7 @@ const BODY_PLACEHOLDERS = [
 const NAV_SCRIPT_PATTERN = /<script[^>]*src="\/?nav\.js"[^>]*>\s*<\/script>/gi;
 const INCLUDE_SCRIPT_PATTERN = /<script[^>]*>[\s\S]*?(header\.html|footer\.html|testimonials-snippet\.html)[\s\S]*?<\/script>/gi;
 const ASSET_SCRIPT_PATTERN = /<script[^>]*src="(?:\.\/)??assets\/[^"]+"[^>]*>\s*<\/script>/gi;
+const TESTIMONIALS_PLACEHOLDER_PATTERN = /<div\s+id="testimonials-include"\s*><\/div>/gi;
 
 const HEAD_REMOVALS = [
   /<meta[^>]+charset[^>]*>/gi,
@@ -47,12 +48,11 @@ export function parseLegacyHtml(html: string, options: ParseOptions = {}) {
     bodyContent = bodyContent.replace(pattern, '');
   }
 
-  if (options.testimonialsSnippet) {
-    bodyContent = bodyContent.replace(
-      /<div\s+id="testimonials-include"\s*><\/div>/gi,
-      options.testimonialsSnippet.trim()
-    );
-  }
+  const testimonialsSnippet = options.testimonialsSnippet?.trim();
+  bodyContent = bodyContent.replace(
+    TESTIMONIALS_PLACEHOLDER_PATTERN,
+    testimonialsSnippet ?? ''
+  );
 
   bodyContent = bodyContent
     .replace(NAV_SCRIPT_PATTERN, '')


### PR DESCRIPTION
## Summary
- always remove the testimonials include placeholder in legacy HTML parsing
- insert a trimmed testimonials snippet when provided

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68c98db28a0083238c6e0dcac79f1f8d