### PR TITLE
Center homepage hero content

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -806,6 +806,33 @@ form button:hover,
 }
 
 /*──────────────────────────────────────────────
+  STANDARD HERO ALIGNMENT
+──────────────────────────────────────────────*/
+.hero:not(.hero-quote) > .box-container,
+.hero:not(.hero-quote) > .hero-container {
+  margin: 0 auto;
+  display: grid;
+  justify-items: center;
+  gap: 1.25rem;
+  text-align: center;
+}
+
+.hero:not(.hero-quote) > .box-container > *:last-child,
+.hero:not(.hero-quote) > .hero-container > *:last-child {
+  margin-bottom: 0;
+}
+
+.hero:not(.hero-quote) > .box-container > p,
+.hero:not(.hero-quote) > .hero-container > p {
+  max-width: 48rem;
+  color: var(--text-light);
+}
+
+.hero:not(.hero-quote) .cta-button {
+  justify-self: center;
+}
+
+/*──────────────────────────────────────────────
   13. STICKY CTA
 ──────────────────────────────────────────────*/
 .sticky-cta {
@@ -827,6 +854,28 @@ form button:hover,
     padding: .75rem 1.3rem;
     font-size: .95rem;
   }
+}
+
+.center-cta {
+  margin-top: 1.5rem;
+  display: flex;
+  justify-content: center;
+}
+
+.center-cta .cta-button {
+  margin: 0;
+}
+
+.home-get-started .box-container {
+  display: grid;
+  gap: 1.25rem;
+  justify-items: center;
+  text-align: center;
+}
+
+.home-get-started .box-container p {
+  max-width: 46rem;
+  color: var(--text-light);
 }
 
 /*──────────────────────────────────────────────

--- a/src/components/LegacyPage.astro
+++ b/src/components/LegacyPage.astro
@@ -12,6 +12,6 @@ const { head, body } = parseLegacyHtml(html, { testimonialsSnippet });
 ---
 
 <BaseLayout>
-  <astro:fragment slot="head" set:html={head} />
-  <astro:fragment set:html={body} />
+  <Fragment slot="head" set:html={head} />
+  <Fragment set:html={body} />
 </BaseLayout>


### PR DESCRIPTION
## Summary
- center-align legacy hero sections so headings, copy, and CTAs render consistently on the homepage
- add shared helpers for centering CTA wrappers and the final call-to-action card

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68c9932b0198832395ebad42d65a3efa