### PR TITLE
Ensure canonical metadata uses html URLs

### DIFF
--- a/src/components/LegacyPage.astro
+++ b/src/components/LegacyPage.astro
@@ -8,7 +8,29 @@ interface Props {
 }
 
 const { html } = Astro.props as Props;
-const { head, body } = parseLegacyHtml(html, { testimonialsSnippet });
+const site = Astro.site ?? Astro.url;
+
+function toHtmlPath(pathname: string) {
+  if (!pathname || pathname === '/') {
+    return '/index.html';
+  }
+
+  const trimmedPath = pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
+
+  if (trimmedPath.endsWith('.html')) {
+    return trimmedPath;
+  }
+
+  return `${trimmedPath}.html`;
+}
+
+const htmlPath = toHtmlPath(Astro.url.pathname);
+const pageUrl = new URL(htmlPath, site).toString();
+
+const { head, body } = parseLegacyHtml(html, {
+  testimonialsSnippet,
+  pageUrl,
+});
 ---
 
 <BaseLayout>

--- a/tests/legacy.test.ts
+++ b/tests/legacy.test.ts
@@ -116,3 +116,25 @@ test('strips legacy head elements while preserving remaining head content', () =
   expect(result.head).not.toMatch(/icon/);
   expect(result.head).not.toMatch(/googletagmanager/);
 });
+
+test('ensures canonical and social URLs include the provided .html page URL', () => {
+  const html = `
+    <html>
+      <head>
+        <link rel="canonical" href="https://example.com/example">
+        <meta property="og:url" content="https://example.com/example">
+        <meta name="twitter:url" content="https://example.com/example">
+      </head>
+      <body></body>
+    </html>
+  `;
+
+  const { head } = parseLegacyHtml(html, {
+    pageUrl: 'https://example.com/example.html',
+  });
+
+  const matches = head.match(/https:\/\/example\.com\/example\.html/g) ?? [];
+
+  expect(matches).toHaveLength(3);
+  expect(head).not.toContain('https://example.com/example"');
+});


### PR DESCRIPTION
## Summary
- derive each legacy-backed page URL from the Astro route and hand it to the legacy parser
- normalize canonical, Open Graph, and Twitter URL metadata so they always include the `.html` filename
- cover the canonical transformation with a unit test and verify the thank-you page keeps its robots meta

## Testing
- CI=1 npm test
- rg -nP 'href="/(?!index\\.html)(?!#)(?!$)(?![^"]*\\.)[^"#?]*"' dist

------
https://chatgpt.com/codex/tasks/task_b_68c9a51df1e88323aa7c66e98a691bad