### PR TITLE
Make quote form grid responsive

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -808,7 +808,8 @@ form button:hover,
 
 .quote-form .form-grid {
   display: grid;
-  gap: 1.1rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.25rem;
 }
 
 .quote-form label {
@@ -1369,5 +1370,8 @@ details[open] summary::after {
   }
   .footer-main {
     font-size: 0.94em !important;
+  }
+  .quote-form .form-grid {
+    grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- define responsive repeat(auto-fit) columns for the quote form grid and adjust spacing
- keep the quote form inputs stacked on narrow screens with a small-screen media query override

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ca9c31b95c8323854099ed49c12927