### PR TITLE
Add optional pageId to BaseLayout body tag

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,6 +2,8 @@
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import navScriptUrl from '../scripts/nav.js?url';
+
+const { pageId = '' } = Astro.props;
 ---
 
 <!DOCTYPE html>
@@ -41,7 +43,7 @@ import navScriptUrl from '../scripts/nav.js?url';
       gtag('config', 'G-GXH0EY936M');
     </script>
   </head>
-  <body>
+  <body data-page={pageId}>
     <a class="skip-link" href="#main-content">Skip to main content</a>
     <Header />
     <div id="main-content">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,7 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
-<BaseLayout>
+<BaseLayout pageId="home">
   <Fragment slot="head">
     <title>
           Independent Building Surveyor | RICS Surveys, Damp Reports &amp; EPCs |


### PR DESCRIPTION
## Summary
- allow BaseLayout consumers to pass an optional pageId prop via Astro frontmatter
- render the body element with a data-page attribute so pages can opt-in
- tag the home page with a pageId of "home" via BaseLayout usage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68caa7a0ccfc8323a502282fdae16eae