### PR TITLE
Restore default section padding for legacy pages

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -163,6 +163,7 @@ main {
   gap: clamp(2.5rem, 6vw, 4rem);
 }
 
+section,
 .section {
   padding-block: clamp(24px, 4vw, 64px);
 }


### PR DESCRIPTION
## Summary
- restore the default section padding by applying the existing `.section` utility styles to all `<section>` elements
- verified key pages (services, testimonials, FAQs) rely on those section wrappers so spacing returns to the pre-refactor layout

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_b_68cab5df7a688323b544bbed4ec0504c