### PR TITLE
Fix mobile overflow and heading scaling

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -39,6 +39,13 @@
 
 html {
   scroll-behavior: smooth;
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
+html,
+body {
+  overflow-x: hidden;
 }
 
 body {
@@ -109,6 +116,13 @@ svg {
   display: block;
 }
 
+input,
+select,
+button,
+textarea {
+  max-width: 100%;
+}
+
 /*───────────────────────────────────────────────────────
   2. TYPOGRAPHY & TEXT STYLES
   Consistent heading and text formatting
@@ -127,7 +141,8 @@ h6 {
 }
 
 h1 {
-  font-size: clamp(2.35rem, 5vw, 2.9rem);
+  font-size: clamp(1.5rem, 5.5vw, 2.75rem);
+  overflow-wrap: anywhere;
 }
 h2 {
   font-size: clamp(1.75rem, 4vw, 2.2rem);
@@ -229,7 +244,7 @@ section {
 section > .box-container {
   background: rgba(255, 255, 255, 0.92);
   width: min(100%, 1150px);
-  max-width: 100vw;
+  max-width: 100%;
   margin: 0 auto;
   padding: clamp(2rem, 5vw, 3rem);
   border-radius: var(--border-radius);
@@ -321,7 +336,8 @@ header {
   justify-content: flex-start;
   gap: 0.75rem;
   margin-bottom: 0;
-  flex-shrink: 0;
+  flex-shrink: 1;
+  min-width: 0;
 }
 
 .logo-link {
@@ -329,6 +345,8 @@ header {
   align-items: center;
   gap: 0.75rem;
   text-decoration: none;
+  flex-wrap: wrap;
+  max-width: 100%;
 }
 
 .logo {
@@ -338,13 +356,18 @@ header {
 }
 
 .site-name {
-  font-size: 1.35rem;
+  font-size: clamp(1rem, 4vw, 1.35rem);
   font-weight: 700;
   color: #fff;
-  line-height: 1.05;
+  line-height: 1.1;
   letter-spacing: 0.03em;
   font-family: var(--heading-font);
   text-transform: uppercase;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .main-nav {
@@ -356,6 +379,8 @@ header {
   margin-left: auto;
   justify-content: flex-end;
   flex: 1 1 auto;
+  max-width: 100%;
+  min-width: 0;
 }
 
 .primary-links,
@@ -1289,7 +1314,7 @@ details[open] summary::after {
   Responsive helpers for legacy imported content
 ───────────────────────────────────────────────────────*/
 .legacy-container {
-  max-width: min(100vw, 600px);
+  max-width: min(100%, 600px);
   margin-inline: auto;
   padding-inline: clamp(1rem, 4vw, 1.5rem);
 }


### PR DESCRIPTION
## Summary
- prevent mobile auto-zoom by locking text-size adjustment and hiding horizontal overflow
- allow the header branding and headings to wrap with smaller clamps for safer mobile sizing
- replace 100vw max-width helpers and cap form controls so elements cannot exceed the viewport

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_b_68cae05d8adc8323a47e12403aba25ce