### PR TITLE
Add damp surveys card to blog index

### DIFF
--- a/src/pages/blog-index.astro
+++ b/src/pages/blog-index.astro
@@ -35,6 +35,10 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <p>Understand the difference between impartial diagnosis and sales-led advice.</p>
         </div>
         <div class="service-card">
+          <h2><a href="/independent-damp-surveys.html">Independent Damp Surveys Explained</a></h2>
+          <p>Discover how unbiased damp assessments identify causes and practical remedies.</p>
+        </div>
+        <div class="service-card">
           <h2><a href="/level-1-or-level-2.html">Do I Need a Level 1 or Level 2 Survey?</a></h2>
           <p>Choose the right RICS survey for newer, conventional homes.</p>
         </div>


### PR DESCRIPTION
## Summary
- add an independent damp surveys card to the blog index grid
- include a concise UK English description and link to the new page

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68cbcc8c661c8323bf3611db50f57336