### PR TITLE
chore(seo): robots.txt sitemap reference and sitemap check

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Allow: /
+
 Sitemap: https://www.lembuildingsurveying.co.uk/sitemap.xml


### PR DESCRIPTION
## Summary
- ensure the public robots.txt explicitly references the production sitemap URL with proper formatting
- verified that the Astro build copies the sitemap.xml into the build output

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cbcc51a578832396ca67116e48df81