### PR TITLE
Add independent damp surveys service page

### DIFF
--- a/src/pages/independent-damp-surveys.astro
+++ b/src/pages/independent-damp-surveys.astro
@@ -1,0 +1,303 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout pageId="independent-damp-surveys">
+  <Fragment slot="head">
+    <title>Independent Damp Surveys in Deeside &amp; Chester | LEM</title>
+    <meta
+      content="Commission an independent damp survey with LEM Building Surveying. We diagnose rising damp, condensation and leaks with impartial, RICS-aligned reporting across Deeside, Flintshire and Chester."
+      name="description"
+    >
+    <meta
+      content="independent damp survey, damp inspection, moisture assessment, damp specialist Deeside, damp survey Chester, impartial damp report, RICS damp surveyor"
+      name="keywords"
+    >
+    <link href="https://www.lembuildingsurveying.co.uk/independent-damp-surveys" rel="canonical">
+    <meta content="Independent Damp Surveys in Deeside &amp; Chester | LEM" property="og:title">
+    <meta
+      content="Independent damp surveys by a RICS-qualified surveyor. Detailed diagnostics and unbiased recommendations for homes in Deeside, Flintshire, Chester and nearby areas."
+      property="og:description"
+    >
+    <meta content="https://www.lembuildingsurveying.co.uk/independent-damp-surveys" property="og:url">
+    <meta content="https://www.lembuildingsurveying.co.uk/logo-sticker.png" property="og:image">
+    <meta content="summary_large_image" name="twitter:card">
+    <meta content="Independent Damp Surveys in Deeside &amp; Chester | LEM" name="twitter:title">
+    <meta
+      content="Independent damp surveys by a RICS-qualified surveyor. Detailed diagnostics and unbiased recommendations for homes in Deeside, Flintshire, Chester and nearby areas."
+      name="twitter:description"
+    >
+    <meta content="https://www.lembuildingsurveying.co.uk/independent-damp-surveys" name="twitter:url">
+    <meta content="https://www.lembuildingsurveying.co.uk/logo-sticker.png" name="twitter:image">
+
+    <script type="application/ld+json" is:inline>
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Home",
+            "item": "https://www.lembuildingsurveying.co.uk/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "Services",
+            "item": "https://www.lembuildingsurveying.co.uk/services"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Independent Damp Surveys",
+            "item": "https://www.lembuildingsurveying.co.uk/independent-damp-surveys"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json" is:inline>
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "How much does an independent damp survey cost?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Costs vary with property size and complexity, but most surveys range between £275 and £450. We confirm a fixed fee in writing before booking so you know exactly what is included."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What diagnostic tools do you use during the inspection?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "We combine calibrated moisture meters, hygrometers, thermal imaging, salts analysis and borescope checks where necessary to trace the source of dampness without destructive works."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Can the report be used for landlords, insurers or mortgage lenders?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. The report is written by a RICS-qualified surveyor and includes readings, photographs and recommendations that satisfy housing disrepair cases, tenancy disputes and lender requests."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Do you recommend specific contractors for remedial work?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "We remain completely independent. Your report outlines the type of remedial work required and the questions to ask when sourcing contractors, but we do not sell treatments or take commission."
+            }
+          }
+        ]
+      }
+    </script>
+  </Fragment>
+
+  <section class="hero">
+    <div class="hero-container">
+      <h1>Independent Damp Surveys</h1>
+      <p>
+        Investigate damp properly with an impartial RICS-qualified surveyor who focuses on diagnosis—not selling treatments.
+      </p>
+      <a class="cta-button" href="/enquiry.html">Request a Survey</a>
+    </div>
+  </section>
+
+  <section class="guide-callout">
+    <div class="box-container">
+      <p>
+        Confused about whether to call a damp-proofing company or an independent expert?
+        Read our <a href="/independent-damp-survey-vs-contractor.html">damp survey vs contractor guide</a>
+        to understand the difference, costs and benefits of impartial advice.
+      </p>
+    </div>
+  </section>
+
+  <section class="service-detail">
+    <div class="box-container">
+      <h2>What Our Independent Damp Survey Covers</h2>
+      <ul>
+        <li>
+          <strong>Rising Damp:</strong> Checking moisture gradients at skirtings and masonry along with salts analysis to confirm if a DPC has failed.
+        </li>
+        <li>
+          <strong>Penetrating Damp:</strong> Investigating roof coverings, external walls, windows and service penetrations for leaks and weathering defects.
+        </li>
+        <li>
+          <strong>Condensation &amp; Mould:</strong> Monitoring humidity, ventilation rates and dew point risks around kitchens, bathrooms and cold surfaces.
+        </li>
+        <li>
+          <strong>Building Fabric &amp; Timber:</strong> Assessing embedded timbers, floors and joinery for decay, wet rot or woodworm linked to excess moisture.
+        </li>
+        <li>
+          <strong>Environmental Factors:</strong> Considering drainage, ground levels and lifestyle contributors that can exacerbate dampness in the property.
+        </li>
+      </ul>
+
+      <h2>Who Books an Independent Damp Survey?</h2>
+      <ul>
+        <li>
+          <strong>Homeowners:</strong> When unexplained damp patches, mould or peeling paint appear and you need objective answers.
+        </li>
+        <li>
+          <strong>Home Buyers:</strong> To understand flagged issues in mortgage valuations or during a RICS home survey before exchanging contracts.
+        </li>
+        <li>
+          <strong>Landlords &amp; Agents:</strong> For evidence-based reporting that helps respond to tenant complaints and comply with housing regulations.
+        </li>
+        <li>
+          <strong>Housing Disrepair Teams:</strong> To support legal cases with independent readings, photographs and impartial recommendations.
+        </li>
+        <li>
+          <strong>Property Managers:</strong> When large or historic buildings require targeted moisture diagnostics before planning remedial work.
+        </li>
+      </ul>
+
+      <h2>How We Investigate Damp Issues</h2>
+      <ol>
+        <li>
+          <strong>Pre-visit consultation:</strong> We review your concerns, previous reports and photographs to plan the inspection efficiently.
+        </li>
+        <li>
+          <strong>Focused site visit:</strong> The surveyor completes visual inspections indoors and out, recording condition, ventilation and drainage risks.
+        </li>
+        <li>
+          <strong>Instrument readings:</strong> Moisture profiles, humidity logging and thermal imaging pinpoint problem areas without unnecessary damage.
+        </li>
+        <li>
+          <strong>Clear explanation:</strong> Before leaving site we explain initial findings and likely causes so you know what to expect from the report.
+        </li>
+      </ol>
+
+      <h2>Your Damp Survey Report Includes</h2>
+      <ul>
+        <li>
+          <strong>Root-cause diagnosis:</strong> Evidence-backed explanation of why damp is occurring and what risks it poses to occupants or structure.
+        </li>
+        <li>
+          <strong>Photographic record:</strong> High-resolution images with annotations that highlight defects, readings and monitoring results.
+        </li>
+        <li>
+          <strong>Prioritised actions:</strong> Step-by-step recommendations with estimated timescales, maintenance tips and suggested specialists to engage.
+        </li>
+        <li>
+          <strong>Ongoing support:</strong> Follow-up call or email to clarify findings and review quotes or remedial proposals if you need a second opinion.
+        </li>
+      </ul>
+
+      <h2>Why Choose a Truly Independent Specialist?</h2>
+      <ul>
+        <li>
+          <strong>No sales agenda:</strong> We do not sell damp-proofing works, ensuring recommendations are based purely on professional judgement.
+        </li>
+        <li>
+          <strong>RICS-aligned reporting:</strong> Surveys follow current guidance and terminology so solicitors, lenders and contractors can act with confidence.
+        </li>
+        <li>
+          <strong>Local knowledge:</strong> We understand building types across Deeside, Flintshire and Cheshire, from solid-walled terraces to modern estates.
+        </li>
+        <li>
+          <strong>Clear communication:</strong> Jargon-free reports and post-survey support help you take the right remedial steps first time.
+        </li>
+      </ul>
+
+      <p>
+        Need broader property advice? Explore our <a href="/damp-mould-surveys.html">damp &amp; mould surveys</a>,
+        <a href="/ventilation-assessments.html">ventilation assessments</a> or view all
+        <a href="/services.html">building surveying services</a> we provide.
+      </p>
+
+      <h2>Frequently Asked Questions</h2>
+      <p>
+        <em>These quick answers address common queries about independent damp investigations:</em>
+      </p>
+      <details open>
+        <summary>How long does the survey and report take?</summary>
+        <p>
+          Most site visits take between one and three hours depending on property size. You will normally receive the written report within three working days, or sooner if the situation is urgent.
+        </p>
+      </details>
+      <details>
+        <summary>Will you need to drill or open up the walls?</summary>
+        <p>
+          The survey is non-destructive. We only carry out minor borescope checks with your permission where hidden voids must be inspected. Our diagnostic equipment allows us to track damp accurately without invasive works.
+        </p>
+      </details>
+      <details>
+        <summary>Can you review quotes from contractors after the report?</summary>
+        <p>
+          Yes. If you receive remedial quotes we are happy to review them against our findings so you proceed with confidence and avoid unnecessary treatments.
+        </p>
+      </details>
+      <details>
+        <summary>Do you travel outside Flintshire and Chester?</summary>
+        <p>
+          Absolutely. While most appointments are in North Wales and Cheshire, we regularly survey properties across the North West—just mention the location when you enquire.
+        </p>
+      </details>
+    </div>
+  </section>
+
+  <section class="home-areas improved-areas">
+    <div class="box-container">
+      <div class="areas-header">
+        <h2>Areas We Cover</h2>
+        <p class="lead">
+          Based in Connah’s Quay, we support homeowners, landlords and agents across Flintshire, Chester and the surrounding region.
+        </p>
+      </div>
+      <div class="areas-content">
+        <div class="dropdown-card">
+          <label class="dropdown-label" for="areaDropdown">Jump to an area:</label>
+          <div class="custom-select">
+            <select id="areaDropdown" onchange="handleAreaSelect(this)">
+              <option value="">Select an area…</option>
+              <option value="/connahs-quay.html">Connah’s Quay</option>
+              <option value="/buckley.html">Buckley</option>
+              <option value="/hawarden.html">Hawarden</option>
+              <option value="/ewloe.html">Ewloe</option>
+              <option value="/deeside.html">Deeside</option>
+              <option value="/broughton.html">Broughton</option>
+              <option value="/flintshire.html">Flintshire</option>
+              <option value="/chester.html">Chester</option>
+              <option value="/cheshire.html">Cheshire</option>
+              <option value="/northop.html">Northop</option>
+              <option value="/northop-hall.html">Northop Hall</option>
+              <option value="/mold.html">Mold</option>
+              <option value="/north-west-of-england.html">North West of England</option>
+            </select>
+            <span class="chevron">⌄</span>
+          </div>
+        </div>
+        <p class="note"><strong>…and neighbouring towns throughout the North West.</strong></p>
+      </div>
+    </div>
+  </section>
+  <script is:inline>
+    /** @param {HTMLSelectElement} select */
+    function handleAreaSelect(select) {
+      if (select.value) window.location.href = select.value;
+    }
+  </script>
+
+  <section class="home-get-started">
+    <div class="box-container">
+      <h2>Ready to Arrange Your Survey?</h2>
+      <p>
+        Share a few details about the property and we’ll confirm availability, fees and what preparation is needed before the visit.
+      </p>
+      <div class="center-cta">
+        <a class="cta-button" href="/enquiry.html">Get My Quote</a>
+      </div>
+    </div>
+  </section>
+
+  <div class="sticky-cta">
+    <a class="cta-button" href="/enquiry.html">Get a Quote</a>
+  </div>
+</BaseLayout>


### PR DESCRIPTION
## Summary
- add an Independent Damp Surveys Astro page that uses the shared BaseLayout and canonical metadata
- include service content detailing scope, process, deliverables, FAQs, internal links, and calls to action
- mirror area coverage dropdown and sticky CTA patterns used across other service pages

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_b_68cbcc8a274c832396cf2227fe5404eb