### PR TITLE
fix(a11y/seo): single h1 and heading hierarchy

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -126,7 +126,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <main>
     <section aria-labelledby="hero-title" class="section hero hero--intro">
       <div class="container hero-intro">
-        <h1 id="hero-title">Independent Property Surveyor</h1>
+        <h2 id="hero-title">Independent Property Surveyor</h2>
         <p class="hero-subtitle">
           Serving Deeside, Chester, Flintshire, Wrexham &amp; the North West with
           trusted inspections &amp; advice

--- a/src/pages/measured-surveys.astro
+++ b/src/pages/measured-surveys.astro
@@ -135,7 +135,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
   </div></section><meta charset="utf-8"><meta content="width=device-width, initial-scale=1" name="viewport"><title>Measured Building Surveys &amp; Floorplans | Plans for Renovations &amp; Extensions | Deeside, Chester, Cheshire</title><meta content="Measured surveys and 2D floorplans for extensions, planning applications and documentation. Serving Deeside, Flintshire, Chester, Wrexham, Cheshire &amp; the wider North West." name="description"><meta content="Measured Building Survey, Floorplans, Site Plans, Elevation Drawings, Section Plans, Renovation Planning, Extension Survey, Property Measurement Chester Deeside Cheshire" name="keywords"><!-- Shared Header --><!-- HERO SECTION --><section class="hero">
   <div class="hero-container">
-  <h1>Measured Building Surveys &amp; Floorplans</h1>
+  <h2>Measured Building Surveys &amp; Floorplans</h2>
   <p>Accurate, professional property measurement and floorplans for renovations, extensions, and documentation.</p>
   <a class="cta-button" href="/enquiry.html">Request a Survey</a>
   </div>
@@ -221,7 +221,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
   </div></section><meta charset="utf-8"><meta content="width=device-width, initial-scale=1" name="viewport"><title>Measured Building Surveys &amp; Floorplans | Plans for Renovations &amp; Extensions | Deeside, Chester, Cheshire</title><meta content="Measured surveys and 2D floorplans for extensions, planning applications and documentation. Serving Deeside, Flintshire, Chester, Wrexham, Cheshire &amp; the wider North West." name="description"><meta content="Measured Building Survey, Floorplans, Site Plans, Elevation Drawings, Section Plans, Renovation Planning, Extension Survey, Property Measurement Chester Deeside Cheshire" name="keywords"><!-- Shared Header --><!-- HERO SECTION --><section class="hero">
   <div class="hero-container">
-  <h1>Measured Building Surveys &amp; Floorplans</h1>
+  <h2>Measured Building Surveys &amp; Floorplans</h2>
   <p>Accurate, professional property measurement and floorplans for renovations, extensions, and documentation.</p>
   <a class="cta-button" href="/enquiry.html">Request a Survey</a>
   </div>
@@ -307,7 +307,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
   </div></section><meta name="twitter:description" content="Measured surveys and 2D floorplans for extensions, planning applications and documentation. Serving Deeside, Flintshire, Chester, Wrexham, Cheshire &amp; the wider North West."><meta name="twitter:url" content="https://www.lembuildingsurveying.co.uk/measured-surveys"><meta name="twitter:image" content="https://www.lembuildingsurveying.co.uk/logo-sticker.png"><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Measured Building Surveys &amp; Floorplans | Plans for Renovations &amp; Extensions | Deeside, Chester, Cheshire</title><meta name="description" content="Measured surveys and 2D floorplans for extensions, planning applications and documentation. Serving Deeside, Flintshire, Chester, Wrexham, Cheshire &amp; the wider North West."><meta name="keywords" content="Measured Building Survey, Floorplans, Site Plans, Elevation Drawings, Section Plans, Renovation Planning, Extension Survey, Property Measurement Chester Deeside Cheshire"><!-- Shared Header --><!-- HERO SECTION --><section class="hero">
       <div class="hero-container">
-        <h1>Measured Building Surveys &amp; Floorplans</h1>
+        <h2>Measured Building Surveys &amp; Floorplans</h2>
         <p>Accurate, professional property measurement and floorplans for renovations, extensions, and documentation.</p>
         <a href="/enquiry.html" class="cta-button">Request a Survey</a>
       </div>
@@ -419,7 +419,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <!-- HERO SECTION -->
     <section class="hero">
       <div class="hero-container">
-        <h1>Measured Building Surveys &amp; Floorplans</h1>
+        <h2>Measured Building Surveys &amp; Floorplans</h2>
         <p>Accurate, professional property measurement and floorplans for renovations, extensions, and documentation.</p>
         <a href="/enquiry.html" class="cta-button">Request a Survey</a>
       </div>
@@ -526,7 +526,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <!-- HERO SECTION -->
     <section class="hero">
       <div class="hero-container">
-        <h1>Measured Building Surveys &amp; Floorplans</h1>
+        <h2>Measured Building Surveys &amp; Floorplans</h2>
         <p>Accurate, professional property measurement and floorplans for renovations, extensions, and documentation.</p>
         <a href="/enquiry.html" class="cta-button">Request a Survey</a>
       </div>
@@ -642,7 +642,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <!-- HERO SECTION -->
     <section class="hero">
       <div class="hero-container">
-        <h1>Measured Building Surveys &amp; Floorplans</h1>
+        <h2>Measured Building Surveys &amp; Floorplans</h2>
         <p>Accurate, professional property measurement and floorplans for renovations, extensions, and documentation.</p>
         <a href="/enquiry.html" class="cta-button">Request a Survey</a>
       </div>
@@ -757,7 +757,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <!-- HERO SECTION -->
     <section class="hero">
       <div class="hero-container">
-        <h1>Measured Building Surveys &amp; Floorplans</h1>
+        <h2>Measured Building Surveys &amp; Floorplans</h2>
         <p>Accurate, professional property measurement and floorplans for renovations, extensions, and documentation.</p>
         <a href="/enquiry.html" class="cta-button">Request a Survey</a>
       </div>


### PR DESCRIPTION
## Summary
- ensure the homepage uses a single `<h1>` by demoting the intro hero heading to `<h2>`
- demote repeated hero headings on the measured surveys page so only the primary hero retains `<h1>`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cbcc32f3e88323bc244afa5e7c5afa