### PR TITLE
fix(ux/seo): descriptive anchor text

### DIFF
--- a/src/pages/farndon.astro
+++ b/src/pages/farndon.astro
@@ -93,7 +93,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   </ul>
   <h2>Next Steps</h2>
   <p>
-          Compare <a href="/comparison.html">Level 1, 2 and 3 surveys here</a>, or contact us for advice on which survey suits your property best.
+          Compare <a href="/comparison.html">Level 1, Level 2, and Level 3 survey options for Farndon homes</a>, or contact us for advice on which survey suits your property best.
         </p>
   <div class="cta-section">
   <a class="cta-button" href="/enquiry.html">Get a Quote</a>

--- a/src/pages/queensferry.astro
+++ b/src/pages/queensferry.astro
@@ -96,7 +96,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           Including Shotton, Sandycroft, Connah’s Quay, Ewloe and Hawarden.
         </p>
   <p>
-          Not sure which survey type is right? <a href="/comparison.html">Compare Level 1, 2 and 3 surveys here</a> or <a href="/contact.html">ask Liam for advice</a>.
+          Not sure which survey type is right? <a href="/comparison.html">Compare Level 1, Level 2, and Level 3 surveys for Queensferry homes</a> or <a href="/contact.html">ask Liam for advice</a>.
         </p>
   <!-- CTA -->
   <div class="cta-section">

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -108,7 +108,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
               <a href="/independent-damp-survey-vs-contractor.html">damp survey vs contractor comparison</a>
               first.
             </p>
-            <a class="inline-link" href="/damp-timber-surveys.html">Learn more about Damp &amp; Timber Surveys →</a>
+            <a class="inline-link" href="/damp-timber-surveys.html">Review our Damp &amp; Timber Surveys for Deeside and Chester →</a>
           </div>
         </article>
         <!-- Measured Surveys -->

--- a/src/pages/shotton.astro
+++ b/src/pages/shotton.astro
@@ -95,7 +95,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   </ul>
   <h2>Ready to Book?</h2>
   <p>
-          If you’re unsure which survey is right, <a href="/comparison.html">compare survey levels here</a> or <a href="/contact.html">send us a message</a> for honest advice.
+          If you’re unsure which survey is right, <a href="/comparison.html">compare RICS survey levels for Shotton properties</a> or <a href="/contact.html">send us a message</a> for honest advice.
         </p>
   <div class="cta-section">
   <a class="cta-button" href="/enquiry.html">Request a Quote</a>

--- a/src/pages/tarporley.astro
+++ b/src/pages/tarporley.astro
@@ -94,7 +94,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   </ul>
   <h2>Get a Quote or Ask a Question</h2>
   <p>
-          Unsure which survey to choose? <a href="/comparison.html">Compare survey types here</a> or <a href="/contact.html">send a quick message</a> for advice. We’re always happy to help.
+          Unsure which survey to choose? <a href="/comparison.html">Compare Tarporley survey types side by side</a> or <a href="/contact.html">send a quick message</a> for advice. We’re always happy to help.
         </p>
   <div class="cta-section">
   <a class="cta-button" href="/enquiry.html">Request a Quote</a>


### PR DESCRIPTION
## Summary
- replace generic "here" anchors on location-specific survey pages with location-aware survey comparison link text
- refresh the damp and timber service link to highlight Deeside and Chester coverage

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_68cbcc50419c8323b643262af52b0f7a