### PR TITLE
Add card for commissioning independent damp surveys

### DIFF
--- a/src/pages/blog-index.astro
+++ b/src/pages/blog-index.astro
@@ -31,6 +31,10 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <p>Compare inspection depth, reporting style, costs and turnaround times.</p>
         </div>
         <div class="service-card">
+          <h2><a href="/independent-damp-surveys.html">When to Commission an Independent Damp Survey</a></h2>
+          <p>Recognise early damp indicators, instruct an impartial surveyor and plan cost-effective remedial works.</p>
+        </div>
+        <div class="service-card">
           <h2><a href="/independent-damp-survey-vs-contractor.html">Independent Damp Survey vs Contractor Report</a></h2>
           <p>Understand the difference between impartial diagnosis and sales-led advice.</p>
         </div>


### PR DESCRIPTION
## Summary
- add a new service card on the blog index highlighting when to commission an independent damp survey

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68cbd8424f5c83239b386e9831022cc1