### PR TITLE
Update contact page social meta descriptions

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -6,16 +6,17 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <Fragment slot="head">
     <title>Contact LEM Building Surveying Ltd | Phone &amp; Email</title>
 
-        <meta name="description" content="Call or email LEM Building Surveying Ltd for independent property survey advice across Deeside, Chester &amp; the North West.">
+        <meta name="description" content="Call 07378 732 037 or email for independent building survey advice across Deeside, Chester &amp; the North West—expect a response within the hour.">
         <meta name="keywords" content="building surveyor contact, surveyor phone Deeside, property survey email Chester">
         <link rel="canonical" href="https://www.lembuildingsurveying.co.uk/contact">
         <meta property="og:title" content="Contact LEM Building Surveying Ltd | Phone &amp; Email">
-        <meta property="og:description" content="">
+        <meta property="og:description" content="Call 07378 732 037 or email for independent building survey advice across Deeside, Chester &amp; the North West—expect a response within the hour.">
         <meta property="og:url" content="https://www.lembuildingsurveying.co.uk/contact">
         <meta property="og:image" content="https://www.lembuildingsurveying.co.uk/logo-sticker.png">
+        <meta property="og:type" content="website">
         <meta name="twitter:card" content="summary_large_image">
         <meta name="twitter:title" content="Contact LEM Building Surveying Ltd | Phone &amp; Email">
-        <meta name="twitter:description" content="">
+        <meta name="twitter:description" content="Call 07378 732 037 or email for independent building survey advice across Deeside, Chester &amp; the North West—expect a response within the hour.">
         <meta name="twitter:url" content="https://www.lembuildingsurveying.co.uk/contact">
         <meta name="twitter:image" content="https://www.lembuildingsurveying.co.uk/logo-sticker.png">
 


### PR DESCRIPTION
## Summary
- highlight the contact page meta description with the phone number and fast response promise
- reuse that description for Open Graph and Twitter tags
- declare the Open Graph type as `website`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cbf7a1f25083238829710a6e8cf62a