### PR TITLE
Update site copy to clarify AssocRICS status and services

### DIFF
--- a/src/pages/broughton.astro
+++ b/src/pages/broughton.astro
@@ -4,8 +4,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
 <BaseLayout>
   <Fragment slot="head">
-    <title>Building &amp; Valuation Surveyor in Broughton | LEM Building Surveying Ltd</title>
-    <meta content="Independent building surveyor Broughton and valuation specialist delivering RICS Level 1, 2 &amp; 3 surveys, residential valuations and damp reports for Saltney and nearby areas." name="description">
+    <title>Building Surveyor in Broughton | LEM Building Surveying Ltd</title>
+    <meta content="Independent building surveyor in Broughton delivering RICS Level 1, 2 &amp; 3 surveys, damp reports and tailored property advice for Saltney and nearby areas." name="description">
     <link href="https://www.lembuildingsurveying.co.uk/broughton" rel="canonical">
     <meta content="Home &amp; Building Surveys in Broughton | LEM Building Surveying Ltd" property="og:title">
     <meta content="Trusted building surveyor in Broughton providing RICS Level 1, 2 and 3 Home Surveys, Building Surveys &amp; Damp Reports. Clear, local, and professional service." property="og:description">
@@ -67,8 +67,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
   <!-- Shared Header --><!-- HERO SECTION --><section class="hero">
   <div class="hero-container">
-  <h1>Building &amp; Valuation Surveys in Broughton</h1>
-  <p>Independent RICS Home Surveys, valuation services, Damp Reports, and expert property inspections for buyers, landlords, and homeowners in Broughton.</p>
+  <h1>Building Surveys in Broughton</h1>
+  <p>Independent RICS Home Surveys, Damp Reports, and expert property inspections for buyers, landlords, and homeowners in Broughton.</p>
   <a class="cta-button" href="/enquiry.html">Request a Quote</a>
   </div>
   </section><!-- MAIN CONTENT SECTION --><section class="service-detail">
@@ -88,9 +88,9 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <li><strong>EPCs with Floorplans:</strong> Combined Energy Performance Certificate and marketing-quality floorplan.</li>
   <li><strong>Residential Ventilation Assessments:</strong> Identifying airflow issues that may be causing condensation, damp or poor air quality.</li>
   </ul>
-  <h2>Valuation &amp; Residential Survey Expertise</h2>
+  <h2>Survey Expertise for Broughton Buyers</h2>
   <p>
-          Looking for a <strong>valuation surveyor in Broughton</strong>? We provide independent market valuations and homebuyer advice across CH4. As experienced <strong>residential surveyors for Saltney</strong> and the surrounding area, we help you understand the local property market, lending requirements and any risks before you commit.
+          Need guidance on a <strong>home survey in Broughton</strong>? We deliver independent reporting and tailored advice across CH4. As experienced <strong>residential surveyors for Saltney</strong> and the surrounding area, we help you understand property condition, maintenance risks and any issues to raise before you commit.
         </p>
   <p><a href="/services.html">View All Services Offered →</a></p>
   <h2>Why Choose LEM?</h2>

--- a/src/pages/chester.astro
+++ b/src/pages/chester.astro
@@ -112,7 +112,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   </ul>
   <p></p>
   <p>
-          Need a <strong>building surveyor in Hoole</strong> or <strong>building surveyor in Churton</strong>? We regularly inspect homes across these suburbs and can combine your visit with a <strong>home buyer survey in Chester</strong> or a follow-up consultation on valuation queries. We are frequently instructed for a <strong>home buyers survey Chester</strong> clients can trust when negotiating.
+          Need a <strong>building surveyor in Hoole</strong> or <strong>building surveyor in Churton</strong>? We regularly inspect homes across these suburbs and can combine your visit with a <strong>home buyer survey in Chester</strong> or a follow-up consultation on survey findings. We are frequently instructed for a <strong>home buyers survey Chester</strong> clients can trust when negotiating.
         </p>
   <h2>Get a Survey or Request Advice</h2>
   <p>

--- a/src/pages/curzon-park.astro
+++ b/src/pages/curzon-park.astro
@@ -83,7 +83,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <li><strong>RICS Level 2 Survey (HomeBuyer):</strong> Ideal for conventional properties — includes condition ratings, repair advice, and ongoing maintenance guidance.</li>
   <li><strong>RICS Level 3 Building Survey:</strong> Detailed inspection suitable for larger, older, or extended properties — with commentary on structure, risks and repair options.</li>
   <li><strong>Damp &amp; Timber Reports:</strong> Investigations for suspected rising damp, mould, or rot with impartial guidance and next steps.</li>
-  <li><strong>Measured Surveys &amp; Floorplans:</strong> Accurate plans for extensions, valuations, or architectural work.</li>
+  <li><strong>Measured Surveys &amp; Floorplans:</strong> Accurate plans for extensions, design proposals, or architectural work.</li>
   <li><strong>Residential Ventilation Assessments:</strong> Checking airflow, condensation risk, and general indoor environment.</li>
   </ul>
   <h2>Why Choose LEM?</h2>

--- a/src/pages/flintshire.astro
+++ b/src/pages/flintshire.astro
@@ -4,8 +4,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
 <BaseLayout>
   <Fragment slot="head">
-    <title>Chartered Surveyors in Flintshire | LEM Building Surveying Ltd</title>
-    <meta content="Chartered surveyors in Flintshire delivering RICS Level 1, 2 &amp; 3 surveys, structural inspections, market valuations and commercial building surveying across North Wales and North West England." name="description">
+    <title>AssocRICS Surveyor in Flintshire | LEM Building Surveying Ltd</title>
+    <meta content="AssocRICS surveyor in Flintshire delivering RICS Level 1, 2 &amp; 3 surveys, structural inspections, damp reports and commercial building surveying across North Wales and North West England." name="description">
     <link href="https://www.lembuildingsurveying.co.uk/flintshire" rel="canonical">
     <meta content="RICS Home &amp; Building Surveys in Flintshire | LEM Building Surveying Ltd" property="og:title">
     <meta content="Independent building surveyor for Flintshire – RICS Home Surveys Level 1, 2 and 3. Damp reports, floorplans &amp; expert inspections. Friendly, clear and fast service." property="og:description">
@@ -67,7 +67,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
   <!-- Shared Header --><!-- HERO SECTION --><section class="hero">
   <div class="hero-container">
-  <h1>Chartered Surveyors in Flintshire</h1>
+  <h1>AssocRICS Surveyor in Flintshire</h1>
   <p>RICS Level 1, 2 &amp; 3 Home Surveys, Damp Reports and tailored inspections for buyers, landlords and homeowners across Flintshire.</p>
   <a class="cta-button" href="/enquiry.html">Request a Survey</a>
   </div>
@@ -75,10 +75,10 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <div class="box-container">
   <h2>Your Local Flintshire Surveyor</h2>
   <p>
-          LEM Building Surveying Ltd provides RICS-aligned property inspections across Flintshire — including Connah’s Quay, Mold, Holywell, Buckley, Northop, and surrounding areas. As <strong>chartered surveyors in Flintshire</strong>, we’re fully independent and committed to clear, actionable reporting that helps you move forward with confidence.
+          LEM Building Surveying Ltd provides RICS-aligned property inspections across Flintshire — including Connah’s Quay, Mold, Holywell, Buckley, Northop, and surrounding areas. As an <strong>AssocRICS surveyor for Flintshire</strong>, we’re fully independent and committed to clear, actionable reporting that helps you move forward with confidence.
         </p>
   <p>
-          Our qualified surveyor is AssocRICS and experienced in surveys carried out on <strong>residential and commercial</strong> buildings. From structural surveys and Level 3 reports to market valuation instructions, every service is delivered with professional standards that provide genuine peace of mind.
+          Our qualified surveyor is AssocRICS and experienced in surveys carried out on <strong>residential and commercial</strong> buildings. From structural surveys and Level 3 reports to specialist inspections, every service is delivered with professional standards that provide genuine peace of mind.
           We offer a full range of professional services so your survey report provides the insight needed for an informed decision.
         </p>
   <h2>Survey Options Available in Flintshire</h2>
@@ -118,7 +118,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   </ul>
   <h2>Book a Survey in Flintshire</h2>
   <p>
-          Get a tailored quote with no obligation. Call <a href="tel:07378732037">07378 732037</a> or use the quick enquiry form below to arrange your chartered building survey, structural inspection or market valuation across the north west of England and North Wales.
+          Get a tailored quote with no obligation. Call <a href="tel:07378732037">07378 732037</a> or use the quick enquiry form below to arrange your building survey, structural inspection or specialist report across the north west of England and North Wales.
         </p>
   <a class="cta-button" href="/enquiry.html">Get a Quote</a>
   </div>

--- a/src/pages/how-much-does-a-level-3-survey-cost-in-chester.astro
+++ b/src/pages/how-much-does-a-level-3-survey-cost-in-chester.astro
@@ -5,14 +5,14 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 <BaseLayout>
   <Fragment slot="head">
     <title>Level 3 Building Survey Cost in Chester | LEM Building Surveying Ltd</title>
-    <meta content="Discover the typical level 3 building survey cost in Chester, what affects pricing, and how a chartered surveyor can tailor a quote for your property." name="description">
+    <meta content="Discover the typical level 3 building survey cost in Chester, what affects pricing, and how an AssocRICS surveyor can tailor a quote for your property." name="description">
   </Fragment>
 
   <!-- Shared Header --><!-- BLOG ARTICLE --><section class="services-box">
   <div class="container">
   <h1>How Much Does a Level 3 Building Survey Cost in Chester?</h1>
   <p><strong>Typical costs, what influences the price, and why it’s worth the investment.</strong></p>
-  <p>If you're buying a property in Chester and need a comprehensive inspection, a <a href="/level-3.html">RICS Level 3 Building Survey</a> offers the deepest analysis. But how much should you expect to pay for a report carried out by chartered surveyors?</p>
+  <p>If you're buying a property in Chester and need a comprehensive inspection, a <a href="/level-3.html">RICS Level 3 Building Survey</a> offers the deepest analysis. But how much should you expect to pay for a report carried out by an experienced RICS surveyor?</p>
   <h2>Average Level 3 Survey Fees in Chester</h2>
   <p>For most homes in Chester, Level 3 survey prices start from around £700 and can exceed £1,200 for large or complex properties. This level 3 building survey cost varies because every survey report is tailored to the property. Factors that affect the fee include:</p>
   <ul>
@@ -26,7 +26,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <h2>Why Costs Vary</h2>
   <p>A period townhouse in the city centre requires more time than a modern terrace. At LEM Building Surveying, we tailor each quote to the property so you only pay for the time needed. Your surveyor considers the type of survey requested, the number of rooms, roofing complexity and whether additional services such as damp testing or measured surveys are required.</p>
   <p>
-        As chartered surveyors we also advise on when a <a href="/cheshire.html">home condition report in Chester</a> or a Level 2 survey may be sufficient—especially if a lender simply needs confirmation of the property’s condition. If you’re comparing <strong>home condition reports Chester cost</strong> with a full Level 3 inspection, we’ll outline the differences so you can choose the right option.
+        As an AssocRICS-qualified surveying practice we also advise on when a <a href="/cheshire.html">home condition report in Chester</a> or a Level 2 survey may be sufficient—especially if a lender simply needs confirmation of the property’s condition. If you’re comparing <strong>home condition reports Chester cost</strong> with a full Level 3 inspection, we’ll outline the differences so you can choose the right option.
       </p>
   <h2>Value for Money</h2>
   <p>A Level 3 survey can reveal hidden defects that might cost thousands to fix. Investing in a detailed report now can give you leverage to renegotiate or budget for repairs. The finished survey report includes photographs, guidance and priority ratings so you know which issues to tackle first.</p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -358,7 +358,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           </p>
           <ul>
             <li>
-              <a href="/flintshire.html">Chartered surveyors in Flintshire</a>
+              <a href="/flintshire.html">AssocRICS surveyor in Flintshire</a>
               providing structural surveys and RICS Level 3 reports.
             </li>
             <li>
@@ -366,7 +366,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
               homebuyer and building survey options.
             </li>
             <li>
-              <a href="/broughton.html">Building &amp; valuation surveys in Broughton</a>
+              <a href="/broughton.html">Building surveys in Broughton</a>
               plus residential surveyors for nearby Saltney.
             </li>
             <li>

--- a/src/pages/level-1.astro
+++ b/src/pages/level-1.astro
@@ -6,7 +6,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <Fragment slot="head">
     <title>RICS Level 1 Condition Report | Independent Surveyor Chester &amp; NW</title>
     <meta content="Need a quick health-check on a modern home? Our RICS Level 1 Condition Report gives you clear, traffic-light ratings and peace of mind—fast." name="description">
-    <meta content="RICS Level 1 survey, Condition Report, basic home survey, chartered surveyor Chester, building surveyor Deeside, Flintshire, Wrexham, Cheshire, North West property survey" name="keywords">
+    <meta content="RICS Level 1 survey, Condition Report, basic home survey, AssocRICS surveyor Chester, building surveyor Deeside, Flintshire, Wrexham, Cheshire, North West property survey" name="keywords">
     <link href="https://www.lembuildingsurveying.co.uk/level-1" rel="canonical">
     <meta content="RICS Level 1 Condition Report | Independent Surveyor Chester &amp; NW" property="og:title">
     <meta content="Need a quick health-check on a modern home? Our RICS Level 1 Condition Report gives you clear, traffic-light ratings and peace of mind—fast." property="og:description">
@@ -74,7 +74,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   </ul>
   <h2>Why Choose LEM Building Surveying</h2>
   <ul>
-  <li><strong>AssocRICS-qualified:</strong> Trusted, chartered expertise with local knowledge</li>
+  <li><strong>AssocRICS-qualified:</strong> Trusted expertise with local knowledge</li>
   <li><strong>No upsells:</strong> Independent, impartial advice—never tied to contractors</li>
   <li><strong>Fast turnaround:</strong> Most Level 1 reports delivered within 48 hours</li>
   <li><strong>Regional insight:</strong> We know the common risks in Chester, Wrexham &amp; North Wales</li>

--- a/src/pages/level-2.astro
+++ b/src/pages/level-2.astro
@@ -44,7 +44,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             "name": "Does the Level 2 survey include a valuation or reinstatement figure?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "A standard Level 2 inspection does not include a market valuation or insurance reinstatement cost. If you need either figure, let us know when you enquire and we can add the service for a small additional fee."
+              "text": "A standard Level 2 inspection does not include a market valuation or insurance reinstatement cost. If you need either figure, you will need to obtain it separately from a qualified valuation specialist."
             }
           },
           {
@@ -173,7 +173,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           Chester, Deeside, Wrexham and across the North West
         </li>
         <li>
-          <strong>Flexible extras:</strong> Add valuations, drone photography or
+          <strong>Flexible extras:</strong> Add drone photography or
           ventilation testing when required
         </li>
       </ul>
@@ -208,9 +208,9 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         </summary>
         <p>
           Valuations and insurance reinstatement figures are not part of the
-          standard Level 2 package. We can provide either service for a modest
-          additional fee—just mention it when you enquire so we can gather the
-          right market data.
+          standard Level 2 package, and we do not provide them. You will need to
+          request these from a suitably qualified valuation professional if
+          required.
         </p>
       </details>
       <details>

--- a/src/pages/understanding-rics-home-surveys.astro
+++ b/src/pages/understanding-rics-home-surveys.astro
@@ -28,7 +28,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <h2>What Are RICS Home Surveys?</h2>
           <p>
             RICS Home Surveys are professional inspections conducted by surveyors accredited by the Royal Institution of
-            Chartered Surveyors. Each type of survey offers a different depth of investigation, but they all involve a
+            Chartered Surveyors (RICS). Each type of survey offers a different depth of investigation, but they all involve a
             thorough inspection, identification of potential defects and recommendations for repairs or maintenance【151469298817208†screenshot】.
             The findings are compiled into a property condition report that provides a reliable overview of the
             building’s current state.
@@ -114,7 +114,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <p>
             RICS Home Surveys are a vital tool for homebuyers and property owners. By understanding the different
             levels and choosing the right survey, you can make confident, informed decisions. If you’re buying in
-            Cheshire, Flintshire or Wrexham, our accredited surveyors can help you select and carry out the appropriate
+            Cheshire, Flintshire or Wrexham, our AssocRICS surveyor can help you select and carry out the appropriate
             survey. Explore our
             <a href="/level-1.html">Level&nbsp;1</a>, <a href="/level-2.html">Level&nbsp;2</a> and
             <a href="/level-3.html">Level&nbsp;3</a> services to learn more, or call <a href="tel:07378732037">07378&nbsp;732037</a>

--- a/src/pages/westminster-park.astro
+++ b/src/pages/westminster-park.astro
@@ -83,7 +83,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <li><strong>Level 2 RICS Home Survey:</strong> Popular HomeBuyer Report with repair advice, condition ratings and maintenance recommendations.</li>
   <li><strong>Level 3 RICS Building Survey:</strong> The most detailed inspection — suitable for larger, older or extended properties.</li>
   <li><strong>Damp &amp; Timber Reports:</strong> Clear guidance on visible or suspected issues, including rot, condensation or rising damp.</li>
-  <li><strong>Measured Surveys &amp; Floorplans:</strong> Accurate layout drawings for extensions, planning or valuation work.</li>
+  <li><strong>Measured Surveys &amp; Floorplans:</strong> Accurate layout drawings for extensions, planning or property records.</li>
   <li><strong>Ventilation Assessments:</strong> Indoor air quality and airflow assessments to prevent damp and mould issues.</li>
   </ul>
   <h2>Why Work with LEM?</h2>


### PR DESCRIPTION
## Summary
- Replace references to chartered surveyors with AssocRICS wording across service and area pages.
- Remove language implying that valuation services are offered and update FAQs to direct enquiries to valuation specialists.
- Adjust related page links and service descriptions to keep measured survey copy focused on survey deliverables.

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68cd8e2dc340832385579cbf4e3dc622