### PR TITLE
Add HTML canonical detection to post deploy validator

### DIFF
--- a/scripts/post_deploy_validator.py
+++ b/scripts/post_deploy_validator.py
@@ -5,10 +5,28 @@ from __future__ import annotations
 
 import argparse
 import csv
+from html.parser import HTMLParser
 from pathlib import Path
 from typing import Iterable, Tuple
 
 import requests
+from requests.utils import parse_header_links
+
+
+class CanonicalLinkParser(HTMLParser):
+    """HTML parser that records whether a canonical <link> tag is present."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.has_canonical = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:  # type: ignore[override]
+        if tag.lower() != "link":
+            return
+        for name, value in attrs:
+            if name.lower() == "rel" and value and "canonical" in value.lower():
+                self.has_canonical = True
+                break
 
 
 def read_urls(path: Path) -> Iterable[str]:
@@ -20,12 +38,28 @@ def read_urls(path: Path) -> Iterable[str]:
 
 
 def check_url(url: str, timeout: float) -> Tuple[str, int | None, bool]:
+    """Return URL status code and if canonical metadata exists via header or HTML."""
     try:
         response = requests.get(url, timeout=timeout, allow_redirects=False)
     except Exception:
         return url, None, False
     header = response.headers.get("link", "")
-    has_canonical = 'rel="canonical"' in header.lower()
+    header_links = parse_header_links(header) if header else []
+    has_header_canonical = any(
+        "rel" in link and link["rel"] and "canonical" in link["rel"].lower()
+        for link in header_links
+    )
+
+    has_html_canonical = False
+    if response.status_code == 200:
+        parser = CanonicalLinkParser()
+        try:
+            parser.feed(response.text)
+        except Exception:
+            pass
+        has_html_canonical = parser.has_canonical
+
+    has_canonical = has_header_canonical or has_html_canonical
     return url, response.status_code, has_canonical
 
 
@@ -33,7 +67,7 @@ def write_report(rows: Iterable[Tuple[str, int | None, bool]], output: Path) -> 
     output.parent.mkdir(parents=True, exist_ok=True)
     with output.open("w", newline="", encoding="utf-8") as handle:
         writer = csv.writer(handle)
-        writer.writerow(["URL", "Status", "Has canonical header?"])
+        writer.writerow(["URL", "Status", "Has canonical link/header?"])
         for row in rows:
             writer.writerow(row)
 


### PR DESCRIPTION
## Summary
- parse HTML responses for canonical link elements when checking post-deploy URLs
- treat HTML canonical tags and HTTP Link headers equally when marking the canonical status and update the CSV header label

## Testing
- python3 scripts/post_deploy_validator.py /tmp/test_urls.txt --output /tmp/test_output.csv


------
https://chatgpt.com/codex/tasks/task_b_68cdb1ec471c832386cd9ba3c1cc6b15