### PR TITLE
Align thank-you redirects with canonical URL

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -4,6 +4,6 @@ https://lembuildingsurveying.co.uk/*  https://www.lembuildingsurveying.co.uk/:sp
 
 /enquiry  /thank-you  200
 /contact  /thank-you  200
-/thank-you  /thank-you.html  200
+/thank-you.html  /thank-you  301
 /level-2-or-level-3  /level-2-vs-level-3  301
 /level-2-or-level-3.html  /level-2-vs-level-3.html  301

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -76,7 +76,7 @@
   <url><loc>https://www.lembuildingsurveying.co.uk/tarvin.html</loc><lastmod>2025-09-19</lastmod></url>
   <url><loc>https://www.lembuildingsurveying.co.uk/tattenhall.html</loc><lastmod>2025-09-19</lastmod></url>
   <url><loc>https://www.lembuildingsurveying.co.uk/testimonials.html</loc><lastmod>2025-09-19</lastmod></url>
-  <url><loc>https://www.lembuildingsurveying.co.uk/thank-you.html</loc><lastmod>2025-09-19</lastmod></url>
+  <url><loc>https://www.lembuildingsurveying.co.uk/thank-you</loc><lastmod>2025-09-19</lastmod></url>
   <url><loc>https://www.lembuildingsurveying.co.uk/understanding-rics-home-surveys.html</loc><lastmod>2025-09-19</lastmod></url>
   <url><loc>https://www.lembuildingsurveying.co.uk/understanding-your-survey-report.html</loc><lastmod>2025-09-19</lastmod></url>
   <url><loc>https://www.lembuildingsurveying.co.uk/ventilation-assessments.html</loc><lastmod>2025-09-19</lastmod></url>

--- a/src/pages/enquiry.astro
+++ b/src/pages/enquiry.astro
@@ -37,7 +37,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           </p>
           <!-- Formspree: _next ensures redirect after successful send -->
           <form action="https://formspree.io/f/xzzdqqqz" class="enquiry-form" method="POST">
-            <input name="_next" type="hidden" value="https://www.lembuildingsurveying.co.uk/thank-you.html">
+            <input name="_next" type="hidden" value="https://www.lembuildingsurveying.co.uk/thank-you">
             <label for="name">Full Name:</label>
             <input id="name" name="name" required="" type="text">
 
@@ -147,7 +147,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             if (resp.ok) {
               /* fire Google-Ads conversion before leaving */
               gtag("event", "conversion", { send_to: "AW-XXXXXXXXXX/AbCdEFgHiJk" });
-              window.location = "/thank-you.html";
+              window.location = "/thank-you";
             } else {
               alert("Sorry, something went wrong. Please email us directly.");
             }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -63,7 +63,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         class="quote-form"
         method="POST"
       >
-        <input name="_next" type="hidden" value="/thank-you.html" />
+        <input name="_next" type="hidden" value="/thank-you" />
         <div class="form-grid">
           <label class="field">Your Name
             <input autocomplete="name" name="name" placeholder="e.g. Jane Smith" required type="text" />

--- a/src/pages/rics-home-surveys.astro
+++ b/src/pages/rics-home-surveys.astro
@@ -176,7 +176,7 @@ const ricsFaqJsonLd = {
             secure your survey date.
           </p>
           <form action="https://formspree.io/f/xzzdqqqz" class="quote-form" method="POST">
-            <input name="_next" type="hidden" value="/thank-you.html">
+            <input name="_next" type="hidden" value="/thank-you">
             <div class="form-grid">
               <input name="name" placeholder="Your Name" required="" type="text">
               <input name="email" placeholder="Your Email" required="" type="email">
@@ -560,7 +560,7 @@ const ricsFaqJsonLd = {
                   send_to: "AW-XXXXXXXXXX/AbCdEFgHiJk",
                 });
               }
-              window.location.href = "/thank-you.html";
+              window.location.href = "/thank-you";
             } else {
               alert("Sorry, something went wrong. Please email us directly.");
             }


### PR DESCRIPTION
## Summary
- make `/thank-you` the canonical success page by redirecting the HTML variant to it
- update form `_next` targets and JS redirects to use the extensionless URL across lead forms
- refresh the sitemap entry to reflect the canonical thank-you location

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_b_68cdb90a06e883239a285e6b9b32af42