### PR TITLE
SEO: first-party reviews as partials + guarded Product AggregateRating (rating=5.0) (REV-25.09.17)

### DIFF
--- a/public/assets/js/includes.js
+++ b/public/assets/js/includes.js
@@ -1,0 +1,21 @@
+/* Loads any <div data-include="/path/to/file.html"> with the file’s HTML */
+(function () {
+  function inject(el, html) {
+    el.outerHTML = html;
+  }
+  function load(el) {
+    var url = el.getAttribute("data-include");
+    if (!url) return;
+    fetch(url, { credentials: "same-origin" })
+      .then(function (r) {
+        return r.ok ? r.text() : "";
+      })
+      .then(function (html) {
+        if (html) inject(el, html);
+      })
+      .catch(function () {});
+  }
+  document.addEventListener("DOMContentLoaded", function () {
+    document.querySelectorAll("[data-include]").forEach(load);
+  });
+})();

--- a/public/assets/js/review-schema.js
+++ b/public/assets/js/review-schema.js
@@ -1,0 +1,88 @@
+// Emits Product + AggregateRating JSON-LD only when first-party reviews exist on the page
+(function () {
+  var emitted = false;
+
+  function hasFirstPartyReview() {
+    return document.querySelector(
+      ".first-party-reviews [itemprop='reviewBody'], .first-party-reviews [data-review]"
+    );
+  }
+
+  function emit() {
+    if (emitted) return;
+
+    try {
+      var root = document.querySelector("[data-product-key]");
+      if (!root) return;
+
+      var key = root.getAttribute("data-product-key");
+      if (!key) return;
+
+      // Require first-party reviews (not third-party widgets)
+      if (!hasFirstPartyReview()) return;
+
+      emitted = true;
+
+      var jsonUrl = "/data/reviews.json?v=" + (window.REV || "REV-25.09.17");
+
+      fetch(jsonUrl, { credentials: "same-origin" })
+        .then(function (r) {
+          return r.ok ? r.json() : Promise.reject(r.status);
+        })
+        .then(function (data) {
+          var item = data[key];
+          if (!item || !item.reviewCount || !item.ratingValue) return;
+
+          var payload = {
+            "@context": "https://schema.org",
+            "@type": "Product",
+            name: item.name,
+            description: item.description,
+            brand: { "@type": "Organization", name: "LEM Building Surveying Ltd" },
+            aggregateRating: {
+              "@type": "AggregateRating",
+              ratingValue: String(item.ratingValue),
+              reviewCount: String(item.reviewCount),
+              bestRating: "5",
+              worstRating: "1",
+            },
+          };
+
+          var s = document.createElement("script");
+          s.type = "application/ld+json";
+          s.text = JSON.stringify(payload);
+          document.head.appendChild(s);
+        })
+        .catch(function () {});
+    } catch (e) {}
+  }
+
+  function onReady() {
+    if (hasFirstPartyReview()) {
+      emit();
+      return;
+    }
+
+    var observer = new MutationObserver(function (_, obs) {
+      if (hasFirstPartyReview()) {
+        obs.disconnect();
+        emit();
+      }
+    });
+
+    try {
+      observer.observe(document.documentElement || document.body, {
+        childList: true,
+        subtree: true,
+      });
+    } catch (e) {
+      emit();
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", onReady);
+  } else {
+    onReady();
+  }
+})();

--- a/public/data/reviews.json
+++ b/public/data/reviews.json
@@ -1,0 +1,26 @@
+{
+  "level-1": {
+    "name": "RICS Level 1 Home Survey (Condition Report)",
+    "description": "Traffic-light condition overview for newer or well-maintained homes.",
+    "ratingValue": 5.0,
+    "reviewCount": 0
+  },
+  "level-2": {
+    "name": "RICS Level 2 Home Survey (HomeBuyer Survey)",
+    "description": "Most popular pre-purchase report with photos and advice.",
+    "ratingValue": 5.0,
+    "reviewCount": 2
+  },
+  "level-3": {
+    "name": "RICS Level 3 Building Survey",
+    "description": "Comprehensive fabric and structural analysis for older or altered homes.",
+    "ratingValue": 5.0,
+    "reviewCount": 2
+  },
+  "epc": {
+    "name": "EPC & Floorplans",
+    "description": "Energy Performance Certificates and estate-agent ready floorplans.",
+    "ratingValue": 5.0,
+    "reviewCount": 1
+  }
+}

--- a/public/partials/reviews-epc.html
+++ b/public/partials/reviews-epc.html
@@ -1,0 +1,16 @@
+<section class="first-party-reviews" aria-label="Customer reviews for EPCs and floorplans">
+  <h2>What our EPC and floorplan clients say</h2>
+
+  <article itemscope itemtype="https://schema.org/Review">
+    <p itemprop="reviewBody">
+      Highly professional and reliable. We used LEM for EPCs with floorplans for a house sale and were delighted with the result.
+    </p>
+    <footer>
+      <strong itemprop="author" itemscope itemtype="https://schema.org/Person"><span itemprop="name">Helen Hawksett</span></strong>
+      <time itemprop="datePublished" datetime="2025-06">Jun 2025</time>
+      <span itemprop="reviewRating" itemscope itemtype="https://schema.org/Rating" aria-label="5 out of 5 stars">★★★★★
+        <meta itemprop="ratingValue" content="5"/><meta itemprop="bestRating" content="5"/><meta itemprop="worstRating" content="1"/>
+      </span>
+    </footer>
+  </article>
+</section>

--- a/public/partials/reviews-level-2.html
+++ b/public/partials/reviews-level-2.html
@@ -1,0 +1,30 @@
+<section class="first-party-reviews" aria-label="Customer reviews for RICS Level 2 Home Survey">
+  <h2>What our Level 2 clients say</h2>
+
+  <article itemscope itemtype="https://schema.org/Review">
+    <p itemprop="reviewBody">
+      We used Liam for a Level 2 Survey and found him responsive, professional and knowledgeable. He highlighted issues clearly
+      and offered pragmatic advice on next steps. Would highly recommend to friends and family.
+    </p>
+    <footer>
+      <strong itemprop="author" itemscope itemtype="https://schema.org/Person"><span itemprop="name">Lindsey McElmeel</span></strong>
+      <time itemprop="datePublished" datetime="2025-05">May 2025</time>
+      <span itemprop="reviewRating" itemscope itemtype="https://schema.org/Rating" aria-label="5 out of 5 stars">★★★★★
+        <meta itemprop="ratingValue" content="5"/><meta itemprop="bestRating" content="5"/><meta itemprop="worstRating" content="1"/>
+      </span>
+    </footer>
+  </article>
+
+  <article itemscope itemtype="https://schema.org/Review">
+    <p itemprop="reviewBody">
+      Liam couldn’t have been easier to work with—fast responses, great communication, and the survey arrived earlier than expected with clear feedback.
+    </p>
+    <footer>
+      <strong itemprop="author" itemscope itemtype="https://schema.org/Person"><span itemprop="name">Jack Makin</span></strong>
+      <time itemprop="datePublished" datetime="2025-07">Jul 2025</time>
+      <span itemprop="reviewRating" itemscope itemtype="https://schema.org/Rating" aria-label="5 out of 5 stars">★★★★★
+        <meta itemprop="ratingValue" content="5"/><meta itemprop="bestRating" content="5"/><meta itemprop="worstRating" content="1"/>
+      </span>
+    </footer>
+  </article>
+</section>

--- a/public/partials/reviews-level-3.html
+++ b/public/partials/reviews-level-3.html
@@ -1,0 +1,31 @@
+<section class="first-party-reviews" aria-label="Customer reviews for RICS Level 3 Building Survey">
+  <h2>What our Level 3 clients say</h2>
+
+  <article itemscope itemtype="https://schema.org/Review">
+    <p itemprop="reviewBody">
+      We had a RICS Level 3 Home Survey done and were really impressed with how detailed and thorough the report was.
+      Liam kept us informed from start to finish, with excellent communication and a very professional service. Highly recommend!
+    </p>
+    <footer>
+      <strong itemprop="author" itemscope itemtype="https://schema.org/Person"><span itemprop="name">Stella Windsor</span></strong>
+      <time itemprop="datePublished" datetime="2025-08">Aug 2025</time>
+      <span itemprop="reviewRating" itemscope itemtype="https://schema.org/Rating" aria-label="5 out of 5 stars">★★★★★
+        <meta itemprop="ratingValue" content="5"/><meta itemprop="bestRating" content="5"/><meta itemprop="worstRating" content="1"/>
+      </span>
+    </footer>
+  </article>
+
+  <article itemscope itemtype="https://schema.org/Review">
+    <p itemprop="reviewBody">
+      LEM provided an excellent service from start to finish. The report was clear, thorough, and helped me make informed choices.
+      I’d recommend LEM to anyone needing Building Surveying services.
+    </p>
+    <footer>
+      <strong itemprop="author" itemscope itemtype="https://schema.org/Person"><span itemprop="name">Chris Smith</span></strong>
+      <time itemprop="datePublished" datetime="2025-04">Apr 2025</time>
+      <span itemprop="reviewRating" itemscope itemtype="https://schema.org/Rating" aria-label="5 out of 5 stars">★★★★★
+        <meta itemprop="ratingValue" content="5"/><meta itemprop="bestRating" content="5"/><meta itemprop="worstRating" content="1"/>
+      </span>
+    </footer>
+  </article>
+</section>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -4,7 +4,12 @@ import Footer from '../components/Footer.astro';
 import Seo from '../components/Seo.astro';
 import SiteLinks from '../components/SiteLinks.astro';
 
-const { pageId = '', seo = undefined, hideSiteLinks = false } = Astro.props;
+const {
+  pageId = '',
+  seo = undefined,
+  hideSiteLinks = false,
+  productKey = undefined,
+} = Astro.props;
 ---
 
 <!DOCTYPE html>
@@ -71,7 +76,7 @@ const { pageId = '', seo = undefined, hideSiteLinks = false } = Astro.props;
       gtag('config', 'G-GXH0EY936M');
     </script>
   </head>
-  <body data-page={pageId}>
+  <body data-page={pageId} data-product-key={productKey}>
     <a class="skip-link" href="#main-content">Skip to main content</a>
     <Header />
     <div id="main-content">
@@ -79,6 +84,7 @@ const { pageId = '', seo = undefined, hideSiteLinks = false } = Astro.props;
     </div>
     {!hideSiteLinks && <SiteLinks />}
     <Footer />
+    <slot name="body-end" />
     <script type="module" src="/assets/nav.min.js" is:inline></script>
   </body>
 </html>

--- a/src/pages/epc-with-floorplans.astro
+++ b/src/pages/epc-with-floorplans.astro
@@ -2,7 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
-<BaseLayout>
+<BaseLayout productKey="epc">
   <Fragment slot="head">
     <title>EPCs with Floorplans | LEM Building Surveying</title>
     <meta content="Elmhurst-accredited EPCs with 2D floorplans for property sales, lettings, and compliance. Serving Flintshire, Chester, Wrexham, Cheshire &amp; the North West. Fast turnaround available." name="description">
@@ -153,4 +153,9 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
 
   </div></div></section>
+  <div data-include="/partials/reviews-epc.html"></div>
+  <Fragment slot="body-end">
+    <script src="/assets/js/includes.js" defer is:inline></script>
+    <script src="/assets/js/review-schema.js" defer is:inline></script>
+  </Fragment>
 </BaseLayout>

--- a/src/pages/level-1.astro
+++ b/src/pages/level-1.astro
@@ -2,7 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
-<BaseLayout>
+<BaseLayout productKey="level-1">
   <Fragment slot="head">
     <title>RICS Level 1 Condition Report | LEM Building Surveying</title>
     <meta content="Need a quick health-check on a modern home? Our RICS Level 1 Condition Report gives you clear, traffic-light ratings and peace of mind—fast." name="description">
@@ -94,4 +94,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   </div>
   </div>
   </section><p>Want to explore more? Browse our <a href="../blog-index.html">blog articles about RICS Home Surveys</a> for detailed insights and helpful advice.</p><!-- FOOTER --><!-- Load Header via JavaScript -->
+  <Fragment slot="body-end">
+    <script src="/assets/js/includes.js" defer is:inline></script>
+    <script src="/assets/js/review-schema.js" defer is:inline></script>
+  </Fragment>
 </BaseLayout>

--- a/src/pages/level-2.astro
+++ b/src/pages/level-2.astro
@@ -2,7 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
-<BaseLayout>
+<BaseLayout productKey="level-2">
   <Fragment slot="head">
     <title>RICS Level 2 HomeBuyer Report | LEM Building Surveying</title>
     <meta content="Buying a typical home in Chester or the North West? Our RICS Level 2 HomeBuyer Report gives expert advice on repairs, defects &amp; maintenance—no upsells, no fluff." name="description">
@@ -78,6 +78,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       </p>
       <a class="cta-button" href="/enquiry.html">Book Your Survey</a>
     </div>
+    <div data-include="/partials/reviews-level-2.html"></div>
   </section>
   <section class="service-detail">
     <div class="box-container">
@@ -254,4 +255,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <a href="../blog-index.html">blog articles about RICS Home Surveys</a> for
     detailed insights and helpful advice.
   </p>
+  <Fragment slot="body-end">
+    <script src="/assets/js/includes.js" defer is:inline></script>
+    <script src="/assets/js/review-schema.js" defer is:inline></script>
+  </Fragment>
 </BaseLayout>

--- a/src/pages/level-3.astro
+++ b/src/pages/level-3.astro
@@ -2,7 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
-<BaseLayout>
+<BaseLayout productKey="level-3">
   <Fragment slot="head">
     <title>RICS Level 3 Building Survey | LEM Building Surveying</title>
     <meta content="Planning to buy or renovate an older or altered property? Our RICS Level 3 Building Survey offers in-depth analysis, repair advice, and full structural clarity." name="description">
@@ -85,6 +85,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       </p>
       <a class="cta-button" href="/enquiry.html">Request a Survey</a>
     </div>
+    <div data-include="/partials/reviews-level-3.html"></div>
   </section>
   <section class="service-detail">
     <div class="box-container">
@@ -257,4 +258,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     </div>
   </section>
   <!-- FOOTER --><!-- Load Header via JavaScript -->
+  <Fragment slot="body-end">
+    <script src="/assets/js/includes.js" defer is:inline></script>
+    <script src="/assets/js/review-schema.js" defer is:inline></script>
+  </Fragment>
 </BaseLayout>


### PR DESCRIPTION
## Summary
- add reusable first-party review partials for Level 2, Level 3, and EPC services with schema.org microdata
- expose static include loader, guarded review-schema injector, and centralised rating metadata under public assets
- wire Level 1–3 and EPC pages to advertise product keys, embed partials where appropriate, and load the shared scripts via the base layout slot

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_68ce511721448323b96d886cd3b4f426