### PR TITLE
Fix Hawarden page map embed build failure

### DIFF
--- a/src/components/location/LocationPageTemplate.astro
+++ b/src/components/location/LocationPageTemplate.astro
@@ -87,6 +87,8 @@ interface Props {
   faqs: FaqSection;
   neighbourhoods?: NeighbourhoodsSection;
   closing: ClosingSection;
+  mapEmbedUrl?: string;
+  mapEmbedTitle?: string;
 }
 
 const {
@@ -106,6 +108,8 @@ const {
   faqs,
   neighbourhoods,
   closing,
+  mapEmbedUrl,
+  mapEmbedTitle,
 } = Astro.props as Props;
 
 const normalizedPath = canonicalPath.replace(/^\/+/, '').replace(/\/+$/, '');
@@ -118,6 +122,7 @@ const heroDescription = hero.description;
 const heroEyebrow = hero.eyebrow ?? 'Local RICS Surveyors';
 const heroCta = hero.cta ?? { label: 'Request a Quote', href: '/enquiry.html' };
 const heroSecondaryCta = hero.secondaryCta;
+const resolvedMapEmbedTitle = mapEmbedTitle ?? `Map of ${townName}, ${county}`;
 
 const getBreadcrumbSchema = () =>
   JSON.stringify({
@@ -278,6 +283,18 @@ const structuredData = {
               ))}
             </ul>
           </div>
+        ) : null}
+
+        {mapEmbedUrl ? (
+          <iframe
+            class="map-embed"
+            src={mapEmbedUrl}
+            loading="lazy"
+            allowfullscreen=""
+            title={resolvedMapEmbedTitle}
+            width="100%"
+            height="300"
+          ></iframe>
         ) : null}
 
         {faqs?.items?.length ? (

--- a/src/pages/hawarden.astro
+++ b/src/pages/hawarden.astro
@@ -184,7 +184,7 @@ const closing = {
   },
 };
 
-  <iframe allowfullscreen="" height="300" loading="lazy" src="https://www.google.com/maps?q=Hawarden,+Flintshire,+UK&amp;output=embed" class="map-embed" width="100%"></iframe>
+const mapEmbedUrl = 'https://www.google.com/maps?q=Hawarden,+Flintshire,+UK&output=embed';
 
 ---
 <LocationPageTemplate
@@ -204,4 +204,5 @@ const closing = {
   faqs={faqs}
   neighbourhoods={neighbourhoods}
   closing={closing}
+  mapEmbedUrl={mapEmbedUrl}
 />


### PR DESCRIPTION
## Summary
- add optional map embed props to `LocationPageTemplate` so location pages can embed a map within markup
- configure the Hawarden page to use the template property instead of including raw iframe markup in frontmatter

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68ce632c7e6c8323a46ab4670b4331f9