### PR TITLE
Auto embed maps across location template pages

### DIFF
--- a/src/components/location/LocationPageTemplate.astro
+++ b/src/components/location/LocationPageTemplate.astro
@@ -87,6 +87,8 @@ interface Props {
   faqs: FaqSection;
   neighbourhoods?: NeighbourhoodsSection;
   closing: ClosingSection;
+  mapEmbedUrl?: string | null;
+  mapEmbedTitle?: string | null;
 }
 
 const {
@@ -106,6 +108,8 @@ const {
   faqs,
   neighbourhoods,
   closing,
+  mapEmbedUrl: initialMapEmbedUrl,
+  mapEmbedTitle: initialMapEmbedTitle,
 } = Astro.props as Props;
 
 const normalizedPath = canonicalPath.replace(/^\/+/, '').replace(/\/+$/, '');
@@ -118,6 +122,29 @@ const heroDescription = hero.description;
 const heroEyebrow = hero.eyebrow ?? 'Local RICS Surveyors';
 const heroCta = hero.cta ?? { label: 'Request a Quote', href: '/enquiry.html' };
 const heroSecondaryCta = hero.secondaryCta;
+const mapQueryParts = [townName, county, 'UK']
+  .map((part) => part?.toString().trim())
+  .filter((part): part is string => Boolean(part?.length));
+
+const defaultMapEmbedUrl = mapQueryParts.length
+  ? `https://www.google.com/maps?q=${encodeURIComponent(mapQueryParts.join(', '))}&output=embed`
+  : null;
+
+const providedMapEmbedUrl =
+  typeof initialMapEmbedUrl === 'string' ? initialMapEmbedUrl.trim() : undefined;
+
+const resolvedMapEmbedUrl = providedMapEmbedUrl?.length
+  ? providedMapEmbedUrl
+  : defaultMapEmbedUrl;
+
+const providedMapEmbedTitle =
+  typeof initialMapEmbedTitle === 'string' ? initialMapEmbedTitle.trim() : undefined;
+
+const resolvedMapEmbedTitle = providedMapEmbedTitle?.length
+  ? providedMapEmbedTitle
+  : `Map of ${townName}, ${county}`;
+
+const shouldRenderMap = Boolean(resolvedMapEmbedUrl);
 
 const getBreadcrumbSchema = () =>
   JSON.stringify({
@@ -278,6 +305,18 @@ const structuredData = {
               ))}
             </ul>
           </div>
+        ) : null}
+
+        {shouldRenderMap && resolvedMapEmbedUrl ? (
+          <iframe
+            class="map-embed"
+            src={resolvedMapEmbedUrl}
+            loading="lazy"
+            allowfullscreen=""
+            title={resolvedMapEmbedTitle}
+            width="100%"
+            height="300"
+          ></iframe>
         ) : null}
 
         {faqs?.items?.length ? (

--- a/src/pages/connahs-quay.astro
+++ b/src/pages/connahs-quay.astro
@@ -183,6 +183,8 @@ const closing = {
     href: 'tel:07378732037',
   },
 };
+
+const mapEmbedTitle = 'Map showing Connah’s Quay and the wider Deeside area';
 ---
 <LocationPageTemplate
   townName="Connah’s Quay"
@@ -201,4 +203,5 @@ const closing = {
   faqs={faqs}
   neighbourhoods={neighbourhoods}
   closing={closing}
+  mapEmbedTitle={mapEmbedTitle}
 />

--- a/src/pages/hawarden.astro
+++ b/src/pages/hawarden.astro
@@ -184,7 +184,7 @@ const closing = {
   },
 };
 
-  <iframe allowfullscreen="" height="300" loading="lazy" src="https://www.google.com/maps?q=Hawarden,+Flintshire,+UK&amp;output=embed" class="map-embed" width="100%"></iframe>
+const mapEmbedTitle = 'Map showing Hawarden and nearby Flintshire villages';
 
 ---
 <LocationPageTemplate
@@ -204,4 +204,5 @@ const closing = {
   faqs={faqs}
   neighbourhoods={neighbourhoods}
   closing={closing}
+  mapEmbedTitle={mapEmbedTitle}
 />

--- a/src/pages/helsby.astro
+++ b/src/pages/helsby.astro
@@ -169,6 +169,8 @@ const closing = {
     href: 'tel:07378732037',
   },
 };
+
+const mapEmbedTitle = 'Map showing Helsby and surrounding Cheshire villages';
 ---
 <LocationPageTemplate
   townName="Helsby"
@@ -187,4 +189,5 @@ const closing = {
   faqs={faqs}
   neighbourhoods={neighbourhoods}
   closing={closing}
+  mapEmbedTitle={mapEmbedTitle}
 />


### PR DESCRIPTION
## Summary
- generate a default Google Maps embed inside `LocationPageTemplate` so every location page using the shared layout renders a map without inline HTML
- add descriptive map titles for the Hawarden, Connah’s Quay and Helsby pages to match the updated template styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68ce632c7e6c8323a46ab4670b4331f9