### PR TITLE
Fix blog index card markup

### DIFF
--- a/src/pages/blog-index.astro
+++ b/src/pages/blog-index.astro
@@ -23,7 +23,9 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       <h1>Property Survey Advice &amp; Insights</h1>
       <p>Guides from an independent surveyor to help you spot issues early, choose the right inspection and plan remedial work.</p>
     </div>
-  </section><section class="blog-index">
+  </section>
+
+  <section class="blog-index">
     <div class="box-container">
       <div class="service-grid">
         <div class="service-card">
@@ -39,12 +41,12 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <p>Understand the difference between impartial diagnosis and sales-led advice.</p>
         </div>
         <div class="service-card">
-
           <h2><a href="/importance-of-independent-damp-surveys.html">Why Independent Damp Surveys Matter</a></h2>
           <p>Learn how impartial moisture assessments protect your home and save you money.</p>
+        </div>
+        <div class="service-card">
           <h2><a href="/independent-damp-surveys.html">Independent Damp Surveys Explained</a></h2>
           <p>Discover how unbiased damp assessments identify causes and practical remedies.</p>
-          main
         </div>
         <div class="service-card">
           <h2><a href="/level-1-or-level-2.html">Do I Need a Level 1 or Level 2 Survey?</a></h2>
@@ -71,10 +73,11 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <h2><a href="/understanding-rics-home-surveys.html">RICS Home Surveys Guide</a></h2>
           <p>Understand Levels 1, 2 and 3 and choose the right survey.</p>
         </div>
-        main
+        
       </div>
     </div>
-  </section><div class="sticky-cta">
+  </section>
+  <div class="sticky-cta">
     <a class="cta-button" href="/enquiry.html">Get a Quote</a>
   </div>
 </BaseLayout>


### PR DESCRIPTION
## Summary
- separate the extra damp survey link into its own service card so each card only wraps one post preview
- clean up blog index markup by removing stray text and ensuring sections and divs close properly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68ce6f3ebaec832382a9eba8d7c7397e