### PR TITLE
Remove redundant main landmark id from contact page

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -33,7 +33,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             Fast answers from a local, independent surveyor
           </p>
         </div>
-      </section><!-- CONTACT CARD --><main id="main" class="contact-card">
+      </section><!-- CONTACT CARD --><main class="contact-card">
         <div class="box-container">
           <p>
             <strong>Phone:</strong>


### PR DESCRIPTION
## Summary
- remove the redundant `id="main"` from the contact page so it relies on the existing `#main-content` container provided by the layout
- verified that no scripts or links reference `#main`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ce8986ec7483239ff52008b23a6163