### PR TITLE
Remove duplicate Google Analytics tags from pages

### DIFF
--- a/src/pages/comparison.astro
+++ b/src/pages/comparison.astro
@@ -38,7 +38,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           background-color: #f4f4f4;
         }
       </style>
-    <!-- Google tag (gtag.js) -->
   </Fragment>
 
   <!-- Shared Header --><!-- COMPARISON INTRO SECTION --><section class="comparison-intro">

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -19,11 +19,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         <meta name="twitter:description" content="Call 07378 732 037 or email for independent building survey advice across Deeside, Chester &amp; the North West—expect a response within the hour.">
         <meta name="twitter:url" content="https://www.lembuildingsurveying.co.uk/contact.html">
         <meta name="twitter:image" content="https://www.lembuildingsurveying.co.uk/logo-sticker.png">
-
-
-
-
-        <!-- Google tag (gtag.js) -->
   </Fragment>
 
   <!-- Shared header --><!-- HERO --><section class="hero">

--- a/src/pages/level-1.astro
+++ b/src/pages/level-1.astro
@@ -19,14 +19,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <meta content="https://www.lembuildingsurveying.co.uk/logo-sticker.png" name="twitter:image">
   </Fragment>
 
-  <!-- Google tag (gtag.js) --><script is:inline>
-  </script><script is:inline>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-GXH0EY936M');
-  </script><section class="hero">
+  <section class="hero">
   <div class="hero-container">
   <h1>RICS Level 1 Condition Report</h1>
   <p>Quick, affordable insight for modern homes—highlighting key issues without paying for depth you don’t need.</p>

--- a/src/pages/level-2.astro
+++ b/src/pages/level-2.astro
@@ -66,7 +66,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         ]
       }
       </script>
-    <!-- Google tag (gtag.js) -->
   </Fragment>
 
   <section class="hero">

--- a/src/pages/level-3.astro
+++ b/src/pages/level-3.astro
@@ -68,14 +68,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       </script>
   </Fragment>
 
-  <!-- Google tag (gtag.js) --><script is:inline>
-  </script><script is:inline>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-GXH0EY936M');
-  </script>
   <section class="hero">
     <div class="hero-container">
       <h1>RICS Level 3 Building Survey</h1>

--- a/src/pages/thank-you.astro
+++ b/src/pages/thank-you.astro
@@ -30,10 +30,6 @@ const conversionEventScript = hasConversionSendTo
         <!-- Prevent this page from being indexed -->
         <meta content="noindex, nofollow" name="robots">
 
-        <!-- Global site tag (gtag.js) - Google Analytics/Ads -->
-
-
-        <!-- Google tag (gtag.js) -->
   </Fragment>
 
   <main class="thank-you-page">


### PR DESCRIPTION
## Summary
- remove inline Google Analytics loader snippets from the level-specific Astro pages so BaseLayout remains the single source of gtag.js
- drop redundant gtag comments from the contact, comparison, and thank-you pages to avoid empty script shells

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_b_68ce8975c0148323b5cf69609cfbadca