### PR TITLE
Normalize nav paths and update header links

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -2,7 +2,7 @@
   <div class="header-inner container">
     <div class="branding">
       <a
-        href="/index.html"
+        href="/"
         class="logo-link"
         aria-label="LEM Building Surveying Ltd home"
       >
@@ -26,16 +26,16 @@
       </button>
       <div class="nav-links" id="nav-links">
         <ul class="primary-links">
-          <li><a href="/index.html">Home</a></li>
-          <li><a href="/rics-home-surveys.html">RICS Home Surveys</a></li>
+          <li><a href="/">Home</a></li>
+          <li><a href="/rics-home-surveys">RICS Home Surveys</a></li>
         </ul>
         <ul class="secondary-links">
-          <li><a href="/services.html">Services</a></li>
-          <li><a href="/local-surveys.html">Areas We Cover</a></li>
-          <li><a href="/comparison.html">Pricing</a></li>
-          <li><a href="/testimonials.html">Testimonials</a></li>
-          <li><a href="/contact.html">Contact</a></li>
-          <li><a href="/enquiry.html" class="cta">Get a Quote</a></li>
+          <li><a href="/services">Services</a></li>
+          <li><a href="/local-surveys">Areas We Cover</a></li>
+          <li><a href="/comparison">Pricing</a></li>
+          <li><a href="/testimonials">Testimonials</a></li>
+          <li><a href="/contact">Contact</a></li>
+          <li><a href="/enquiry" class="cta">Get a Quote</a></li>
         </ul>
       </div>
     </nav>

--- a/src/scripts/nav.js
+++ b/src/scripts/nav.js
@@ -1,7 +1,9 @@
-function normalizePathname(pathname) {
+const INDEX_HTML_SUFFIX = /\/index\.html$/;
+
+export function normalizePathname(pathname) {
   if (!pathname) return '';
   let normalized = pathname.startsWith('/') ? pathname : `/${pathname}`;
-  normalized = normalized.replace(/\/index\.html$/, '/');
+  normalized = normalized.replace(INDEX_HTML_SUFFIX, '/');
   normalized = normalized.replace(/\.html$/, '');
   if (normalized.length > 1 && normalized.endsWith('/')) {
     normalized = normalized.slice(0, -1);

--- a/tests/nav.test.ts
+++ b/tests/nav.test.ts
@@ -8,7 +8,7 @@ beforeEach(() => {
   document.body.innerHTML = `
     <button class="nav-toggle" aria-expanded="false"></button>
     <div class="nav-links">
-      <a href="/index.html">Home</a>
+      <a href="/">Home</a>
     </div>
   `;
   window.history.pushState({}, '', '/');
@@ -41,6 +41,16 @@ test('loadTrustIndex injects script once', async () => {
 
   const scripts = document.querySelectorAll('script[src^="https://cdn.trustindex.io/loader.js"]');
   expect(scripts).toHaveLength(1);
+});
+
+test('normalizePathname strips index.html and .html suffixes', async () => {
+  const { normalizePathname } = await import(NAV_MODULE_PATH);
+
+  expect(normalizePathname('/index.html')).toBe('/');
+  expect(normalizePathname('/services/index.html')).toBe('/services');
+  expect(normalizePathname('/contact.html')).toBe('/contact');
+  expect(normalizePathname('local-surveys.html')).toBe('/local-surveys');
+  expect(normalizePathname('')).toBe('');
 });
 
 test('highlights .html link when current path is extensionless', async () => {


### PR DESCRIPTION
## Summary
- export and harden `normalizePathname`, ensuring `/index.html` suffixes are stripped before trimming the remaining `.html`
- update the header navigation to use extensionless URLs for internal routes
- extend the navigation tests to cover path normalization and align fixtures with the canonical links

## Testing
- `CI=1 npm run test`
- Manual Playwright check of `/` and `/services` to confirm `aria-current` handling

------
https://chatgpt.com/codex/tasks/task_b_68ce90b6b5ec8323bddbde8f5a06a37a