### PR TITLE
Remove added social images and reuse existing logo asset

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -52,7 +52,7 @@ const currentYear = new Date().getFullYear();
       "@context": "https://schema.org",
       "@type": "LocalBusiness",
       "name": "LEM Building Surveying Ltd",
-      "image": "https://www.lembuildingsurveying.co.uk/images/og-image.jpg",
+      "image": "https://www.lembuildingsurveying.co.uk/logo-sticker.png",
       "telephone": "+447378732037",
       "email": "enquiries@lembuildingsurveying.co.uk",
       "address": {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -24,8 +24,8 @@ const { pageId = '' } = Astro.props;
         "@type": "LocalBusiness",
         "name": "LEM Building Surveying Ltd",
         "url": "https://www.lembuildingsurveying.co.uk",
-        "image": "https://www.lembuildingsurveying.co.uk/logo.png",
-        "logo": "https://www.lembuildingsurveying.co.uk/logo.png",
+        "image": "https://www.lembuildingsurveying.co.uk/logo-sticker.png",
+        "logo": "https://www.lembuildingsurveying.co.uk/logo-sticker.png",
         "telephone": "+44 7378 732 037",
         "description": "Professional building surveying services in Deeside, Flintshire, and across North Wales.",
         "address": {

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -14,12 +14,12 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         <meta content="About LEM Building Surveying Ltd | Liam Butler BSc AssocRICS MRPSA" property="og:title">
         <meta content="Meet Liam Butler BSc AssocRICS MRPSA—independent surveyor serving Deeside, Chester &amp; beyond. Trusted advice, local knowledge, and clear reporting." property="og:description">
         <meta content="https://www.lembuildingsurveying.co.uk/about" property="og:url">
-        <meta content="https://www.lembuildingsurveying.co.uk/images/liam-butler-og.jpg" property="og:image">
+        <meta content="https://www.lembuildingsurveying.co.uk/logo-sticker.png" property="og:image">
         <meta content="summary_large_image" name="twitter:card">
         <meta content="About LEM Building Surveying Ltd | Liam Butler BSc AssocRICS MRPSA" name="twitter:title">
         <meta content="Meet Liam Butler BSc AssocRICS MRPSA—independent surveyor serving Deeside, Chester &amp; beyond. Trusted advice, local knowledge, and clear reporting." name="twitter:description">
         <meta content="https://www.lembuildingsurveying.co.uk/about" name="twitter:url">
-        <meta content="https://www.lembuildingsurveying.co.uk/images/liam-butler-og.jpg" name="twitter:image">
+        <meta content="https://www.lembuildingsurveying.co.uk/logo-sticker.png" name="twitter:image">
         <!-- Open Graph -->
 
 
@@ -31,7 +31,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             "@type": "Organization",
             "name": "LEM Building Surveying Ltd",
             "url": "https://www.lembuildingsurveying.co.uk",
-            "logo": "https://www.lembuildingsurveying.co.uk/images/logo.png",
+            "logo": "https://www.lembuildingsurveying.co.uk/logo-sticker.png",
             "areaServed": [
               "North Wales",
               "Chester",

--- a/src/pages/local-surveys.astro
+++ b/src/pages/local-surveys.astro
@@ -177,7 +177,7 @@ const areas = [
     />
     <meta
       property="og:image"
-      content="https://www.lembuildingsurveying.co.uk/logo.png"
+      content="https://www.lembuildingsurveying.co.uk/logo-sticker.png"
     />
     <meta name="twitter:card" content="summary_large_image" />
     <meta
@@ -194,7 +194,7 @@ const areas = [
     />
     <meta
       name="twitter:image"
-      content="https://www.lembuildingsurveying.co.uk/logo.png"
+      content="https://www.lembuildingsurveying.co.uk/logo-sticker.png"
     />
     <meta name="robots" content="index, follow" />
     <script type="application/ld+json" is:inline>
@@ -202,7 +202,7 @@ const areas = [
         "@context": "https://schema.org",
         "@type": "LocalBusiness",
         "name": "LEM Building Surveying Ltd",
-        "image": "https://www.lembuildingsurveying.co.uk/logo.png",
+        "image": "https://www.lembuildingsurveying.co.uk/logo-sticker.png",
         "telephone": "07378 732037",
         "email": "enquiries@lembuildingsurveying.co.uk",
         "address": {


### PR DESCRIPTION
## Summary
- remove the previously added Open Graph image assets from `public/`
- point sitewide JSON-LD metadata to the existing `/logo-sticker.png`
- update the About and Local Surveys pages to reuse the published logo asset for sharing metadata

## Testing
- npm run build
- npm run preview -- --host 0.0.0.0 --port 4321
- curl -I http://127.0.0.1:4321/logo-sticker.png

------
https://chatgpt.com/codex/tasks/task_b_68ce90ad0d78832392773489124e6bad