### PR TITLE
Add Flintshire and Chester survey blog content

### DIFF
--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -18,10 +18,6 @@ const areaSource = await fs.readFile(areasPath, 'utf8');
 const areaSlugMatches = Array.from(areaSource.matchAll(/createAreaEntry\('([^']+)'/g));
 const areaSlugs = new Set(areaSlugMatches.map((match) => match[1]));
 
-const entries = await fs.readdir(pagesDir, { withFileTypes: true });
-const astroFiles = entries
-  .filter((entry) => entry.isFile() && entry.name.endsWith('.astro') && !skipFiles.has(entry.name))
-  .map((entry) => entry.name);
 const collectAstroFiles = async (dir, relativeDir = '') => {
   const entries = await fs.readdir(dir, { withFileTypes: true });
   const files = [];
@@ -53,13 +49,13 @@ const astroFiles = await collectAstroFiles(pagesDir);
 
 const urls = astroFiles.map((relativePath) => {
   const baseName = relativePath.replace(/\.astro$/, '');
+  const slug = path.basename(baseName);
   if (baseName === 'index') {
     return `${site}/`;
   }
-  if (areaSlugs.has(baseName)) {
-    return `${site}/service-areas/${baseName}-damp-surveys-rics-home-surveys.html`;
+  if (areaSlugs.has(slug)) {
+    return `${site}/service-areas/${slug}-damp-surveys-rics-home-surveys.html`;
   }
-  return `${site}/${baseName}.html`;
   const normalizedPath = baseName.split(path.sep).join('/');
   return `${site}/${normalizedPath}.html`;
 });

--- a/src/pages/blog-index.astro
+++ b/src/pages/blog-index.astro
@@ -39,12 +39,12 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <p>Understand the difference between impartial diagnosis and sales-led advice.</p>
         </div>
         <div class="service-card">
-
           <h2><a href="/importance-of-independent-damp-surveys.html">Why Independent Damp Surveys Matter</a></h2>
           <p>Learn how impartial moisture assessments protect your home and save you money.</p>
+        </div>
+        <div class="service-card">
           <h2><a href="/independent-damp-surveys.html">Independent Damp Surveys Explained</a></h2>
           <p>Discover how unbiased damp assessments identify causes and practical remedies.</p>
-          main
         </div>
         <div class="service-card">
           <h2><a href="/level-1-or-level-2.html">Do I Need a Level 1 or Level 2 Survey?</a></h2>
@@ -71,7 +71,10 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <h2><a href="/understanding-rics-home-surveys.html">RICS Home Surveys Guide</a></h2>
           <p>Understand Levels 1, 2 and 3 and choose the right survey.</p>
         </div>
-        main
+        <div class="service-card">
+          <h2><a href="/rics-home-surveys-in-flintshire-and-chester.html">RICS Home Surveys in Flintshire &amp; Chester Suburbs</a></h2>
+          <p>Explore costs, survey levels and local property issues before you buy.</p>
+        </div>
       </div>
     </div>
   </section><div class="sticky-cta">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -171,9 +171,10 @@ import { areaSelectorOptions } from '../data/areas';
           Need advice fast? Explore our resources on
           <a href="/level-1-or-level-2.html">survey levels</a>,
           <a href="/level-3.html">Level 3 building surveys</a>, or our guide to
-          <a href="/independent-damp-survey-vs-contractor.html">independent damp surveys</a>
-          before booking. Every report is tailored to the property type so you
-          receive actionable insight rather than template commentary.
+          <a href="/independent-damp-survey-vs-contractor.html">independent damp surveys</a>,
+          and visit our <a href="/blog-index.html">blog for property survey advice</a> before
+          booking. Every report is tailored to the property type so you receive
+          actionable insight rather than template commentary.
         </p>
       </div>
     </section>

--- a/src/pages/rics-home-surveys-in-flintshire-and-chester.astro
+++ b/src/pages/rics-home-surveys-in-flintshire-and-chester.astro
@@ -1,0 +1,217 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout>
+  <Fragment slot="head">
+    <title>RICS Home Surveys in Flintshire &amp; Chester Suburbs | LEM Building Surveying</title>
+    <meta
+      content="Comprehensive guide to RICS Home Surveys across the suburbs of Flintshire and Chester. Learn about survey levels, local issues, pricing and how to choose an accredited surveyor."
+      name="description"
+    />
+    <meta
+      content="RICS Home Survey Flintshire, RICS survey Chester, Level 1 survey guide, Level 2 HomeBuyer Report, Level 3 Building Survey, chartered surveyor Flintshire, chartered surveyor Chester"
+      name="keywords"
+    />
+    <link href="https://www.lembuildingsurveying.co.uk/rics-home-surveys-in-flintshire-and-chester.html" rel="canonical" />
+    <meta content="RICS Home Surveys in Flintshire &amp; Chester Suburbs | LEM Building Surveying" property="og:title" />
+    <meta
+      content="Understand the differences between Level 1, 2 and 3 RICS Home Surveys, what they cost locally and how they protect buyers in Flintshire and Chester."
+      property="og:description"
+    />
+    <meta content="https://www.lembuildingsurveying.co.uk/rics-home-surveys-in-flintshire-and-chester.html" property="og:url" />
+    <meta content="https://www.lembuildingsurveying.co.uk/logo-sticker.png" property="og:image" />
+    <meta content="summary_large_image" name="twitter:card" />
+    <meta content="RICS Home Surveys in Flintshire &amp; Chester Suburbs | LEM Building Surveying" name="twitter:title" />
+    <meta
+      content="Understand the differences between Level 1, 2 and 3 RICS Home Surveys, what they cost locally and how they protect buyers in Flintshire and Chester."
+      name="twitter:description"
+    />
+    <meta content="https://www.lembuildingsurveying.co.uk/rics-home-surveys-in-flintshire-and-chester.html" name="twitter:url" />
+    <meta content="https://www.lembuildingsurveying.co.uk/logo-sticker.png" name="twitter:image" />
+  </Fragment>
+
+  <section class="hero">
+    <div class="hero-container">
+      <h1>RICS Home Surveys in Suburbs of Flintshire and Chester: Complete Homebuyer’s Guide</h1>
+      <p>Plan your purchase with an accredited surveyor’s insight into local housing stock, pricing and common defects.</p>
+    </div>
+  </section>
+
+  <section class="blog-content">
+    <div class="box-container">
+      <p>
+        Buying a home is one of life’s biggest investments, and when it comes to properties in the suburbs of Flintshire and
+        Chester, due diligence is key. A RICS Home Survey offers buyers and homeowners the confidence they need to make
+        informed decisions. From uncovering hidden structural problems to identifying damp or energy efficiency concerns, these
+        surveys ensure peace of mind before contracts are signed.
+      </p>
+      <p>
+        In this guide, we explore everything you need to know about RICS Home Surveys in Flintshire and Chester suburbs,
+        including the different survey types, costs, local housing trends, and why hiring a RICS-accredited surveyor is
+        essential.
+      </p>
+
+      <h2>Understanding RICS Home Surveys</h2>
+      <h3>What is a RICS Home Survey?</h3>
+      <p>
+        A RICS Home Survey is an inspection of a property carried out by a surveyor accredited by the Royal Institution of
+        Chartered Surveyors (RICS). It provides detailed insights into the condition of a property, highlighting issues that may
+        not be visible during a standard viewing. Whether it’s structural cracks, outdated wiring or hidden damp, the survey
+        aims to safeguard buyers from costly surprises.
+      </p>
+
+      <h3>Types of RICS Home Surveys (Level 1, 2, and 3)</h3>
+      <ul>
+        <li><strong>Level 1 (Condition Report):</strong> A concise overview of the property’s condition with traffic-light ratings to highlight urgent issues.</li>
+        <li><strong>Level 2 (HomeBuyer Report):</strong> The most popular choice, delivering more detailed observations on defects, urgent repairs and maintenance.</li>
+        <li><strong>Level 3 (Building Survey):</strong> A comprehensive survey suited to older, larger or heavily altered homes that may need in-depth analysis.</li>
+      </ul>
+
+      <h3>Why RICS Accreditation Matters</h3>
+      <p>
+        RICS is internationally recognised and its standards guarantee professional, impartial and regulated service. Using a
+        RICS surveyor ensures reports are accurate, reliable and trusted by lenders, solicitors and contractors involved in the
+        transaction.
+      </p>
+
+      <h2>Importance of RICS Home Surveys in Flintshire and Chester</h2>
+      <h3>Suburban Property Market in Flintshire</h3>
+      <p>
+        Flintshire suburbs feature a mix of modern estates and character-filled cottages dating back to the 19th century. The
+        older stone and brick construction often hides movement, ageing roof coverings and ventilation problems, so a survey
+        helps you plan remedial work before you commit.
+      </p>
+
+      <h3>Housing Trends in Chester Suburbs</h3>
+      <p>
+        Chester’s commuter suburbs, from Hoole to Upton and beyond, blend period terraces with post-war semis. Competitive
+        demand means homes sell quickly, but many still feature traditional materials, timber floors and extensions that need a
+        specialist eye. A thorough survey assesses workmanship and compliance so you buy with confidence.
+      </p>
+
+      <h3>Local Factors Influencing Survey Outcomes</h3>
+      <ul>
+        <li>Historic buildings with unique maintenance needs that require sympathetic repair advice.</li>
+        <li>River Dee flood risks in low-lying Chester neighbourhoods where resilience measures are essential.</li>
+        <li>Weathering in coastal-facing Flintshire villages where prevailing winds accelerate wear on masonry and render.</li>
+      </ul>
+
+      <h2>Choosing the Right Type of Survey</h2>
+      <h3>RICS Level 1: The Condition Report</h3>
+      <p>
+        Level 1 surveys provide a swift overview of general condition, ideal for newer homes or straightforward flats where no
+        significant alterations are anticipated. You receive clear colour-coded ratings and advice on next steps.
+      </p>
+
+      <h3>RICS Level 2: The HomeBuyer Report</h3>
+      <p>
+        Level 2 surveys remain the default option for typical suburban purchases. They examine visible structural issues, damp,
+        insulation, services and outbuildings, and usually include a market valuation alongside reinstatement cost guidance.
+      </p>
+
+      <h3>RICS Level 3: The Building Survey</h3>
+      <p>
+        If you are purchasing an older, unusual or significantly extended property, a Level 3 building survey is recommended.
+        The inspection covers concealed spaces where accessible, outlines repair options, estimates priority works and comments
+        on materials and construction techniques.
+      </p>
+
+      <h2>Common Issues Found in Flintshire and Chester Properties</h2>
+      <h3>Structural Problems in Older Homes</h3>
+      <p>
+        Many suburban homes in Chester and Flintshire date back over a century. Surveys frequently uncover settlement cracks,
+        timber decay in floors and roofs, failing lintels and ageing chimney stacks that need repair before they worsen.
+      </p>
+
+      <h3>Damp, Insulation, and Energy Efficiency Concerns</h3>
+      <p>
+        Properties with solid walls or inadequate ventilation may suffer from condensation and damp ingress. Surveys highlight
+        insulation gaps, insufficient extraction and outdated heating systems, helping you budget for energy upgrades.
+      </p>
+
+      <h3>Boundary and Legal Considerations</h3>
+      <p>
+        Surveyors also review boundaries, extensions and conversions for potential non-compliance with planning or building
+        regulations. Identifying legal or ownership discrepancies early avoids disputes after completion.
+      </p>
+
+      <h2>Cost of RICS Home Surveys in Flintshire and Chester</h2>
+      <h3>Average Prices by Survey Level</h3>
+      <ul>
+        <li>Level 1: £300–£500</li>
+        <li>Level 2: £400–£800</li>
+        <li>Level 3: £700–£1,500+</li>
+      </ul>
+
+      <h3>Factors Affecting Survey Costs</h3>
+      <ul>
+        <li>Property size, layout complexity and the number of bedrooms.</li>
+        <li>Construction age and the anticipated level of investigation required.</li>
+        <li>Travel distance and access arrangements for the surveyor.</li>
+      </ul>
+
+      <h2>Benefits of Getting a RICS Home Survey Before Buying</h2>
+      <h3>Avoiding Unexpected Repair Costs</h3>
+      <p>
+        Comprehensive surveys highlight urgent repairs so you can budget accurately or request remedial works before exchange.
+      </p>
+
+      <h3>Negotiation Leverage During Purchase</h3>
+      <p>
+        Evidence-backed findings give you grounds to renegotiate the purchase price or request allowances for repairs, helping
+        you protect your investment.
+      </p>
+
+      <h3>Peace of Mind for First-Time Buyers</h3>
+      <p>
+        Clear explanations, photographs and follow-up advice reduce the stress of buying your first home and help you plan for
+        ownership with confidence.
+      </p>
+
+      <h2>How to Choose a RICS Chartered Surveyor Locally</h2>
+      <h3>What to Look for in a Surveyor</h3>
+      <ul>
+        <li>Current RICS accreditation with appropriate professional indemnity insurance.</li>
+        <li>Local market knowledge and experience inspecting the same property types.</li>
+        <li>Transparent pricing and clear reporting styles that you can easily understand.</li>
+      </ul>
+
+      <h3>Questions to Ask Before Hiring</h3>
+      <ul>
+        <li>Which survey level do you recommend for my property and why?</li>
+        <li>How soon after inspection will I receive the report and follow-up support?</li>
+        <li>Do you provide cost guidance or maintenance plans for flagged issues?</li>
+      </ul>
+
+      <h3>Local RICS Surveyors in Flintshire and Chester</h3>
+      <p>
+        Several RICS-accredited surveyors operate locally, offering tailored advice for regional property quirks. Working with a
+        nearby expert ensures they can liaise quickly with estate agents, vendors and trades if extra investigations are
+        required.
+      </p>
+
+      <h2>FAQs About RICS Home Surveys in Flintshire and Chester</h2>
+      <p><strong>Do I need a survey for a new-build home in Chester?</strong> Yes. Snagging issues, incomplete finishes and latent defects can still occur, so a Level 1 survey provides reassurance.</p>
+      <p><strong>How long does a RICS Home Survey take?</strong> Smaller homes may take two hours, while complex properties can require most of a day on site.</p>
+      <p><strong>Is a RICS survey different from a mortgage valuation?</strong> Absolutely. A mortgage valuation serves the lender, whereas a RICS survey protects your interests as the buyer.</p>
+      <p><strong>Can a survey lower my purchase price?</strong> Survey evidence often unlocks renegotiations or allows you to request repairs before exchange.</p>
+      <p><strong>How soon should I book a survey in Flintshire or Chester?</strong> Book as soon as your offer is accepted to keep the transaction on schedule.</p>
+      <p><strong>Do RICS surveyors check for asbestos?</strong> They flag potential risks and advise if specialist asbestos testing is required.</p>
+
+      <h2>Conclusion: Making Confident Property Decisions</h2>
+      <p>
+        RICS Home Surveys in Flintshire and Chester suburbs are not just a formality—they are a vital tool for protecting your
+        investment. Whether you’re buying a modern family home in Flintshire or a period property in Chester, a survey ensures
+        you step into homeownership with clarity and confidence. For more information, visit the
+        <a href="https://www.rics.org" rel="noopener" target="_blank">official RICS website</a>.
+      </p>
+
+      <div class="cta-section">
+        <h2>Ready to Book Your Survey?</h2>
+        <p>Contact LEM Building Surveying for tailored advice on the best RICS survey for your next purchase.</p>
+        <a class="cta-button" href="/enquiry.html">Request a Quote</a>
+      </div>
+    </div>
+  </section>
+</BaseLayout>


### PR DESCRIPTION
## Summary
- add a Flintshire and Chester focused RICS Home Survey blog article with structured sections and CTA
- surface the new article on the blog index and link to the blog from the homepage resources copy
- tidy the sitemap generator so Astro check passes without duplicate declarations

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_b_68ce988eeb948323b7b12a85a63ee2f0