### PR TITLE
Add blog index link to homepage guides section

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -269,6 +269,9 @@ import { areaSelectorOptions } from '../data/areas';
             <p>Compare lighter-touch surveys for newer, conventional homes.</p>
           </article>
         </div>
+        <div class="center-cta">
+          <a class="cta-button" href="/blog-index.html">Explore All Articles</a>
+        </div>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- add a call-to-action button in the homepage guides section that links to the blog index for more articles

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_b_68cea8a2b77c8323ba56043caa37e77b