### PR TITLE
Clean up URLs and sitemap

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -229,6 +229,7 @@ https://lembuildingsurveying.co.uk/*  https://www.lembuildingsurveying.co.uk/:sp
 /faqs.html  /faqs  301
 /how-much-does-a-level-3-survey-cost-in-chester.html  /how-much-does-a-level-3-survey-cost-in-chester  301
 /importance-of-independent-damp-surveys.html  /importance-of-independent-damp-surveys  301
+/managing-damp-in-traditional-homes.html  /managing-damp-in-traditional-homes  301
 /independent-damp-survey-vs-contractor.html  /independent-damp-survey-vs-contractor  301
 /independent-damp-surveys.html  /independent-damp-surveys  301
 /level-1.html  /level-1  301

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -14,5 +14,5 @@ Services:
 
 Canonical URLs:
 - Home: https://www.lembuildingsurveying.co.uk/
-- Services Overview: https://www.lembuildingsurveying.co.uk/services.html
-- RICS Home Surveys: https://www.lembuildingsurveying.co.uk/rics-home-surveys.html
+- Services Overview: https://www.lembuildingsurveying.co.uk/services
+- RICS Home Surveys: https://www.lembuildingsurveying.co.uk/rics-home-surveys

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
 Allow: /
+Disallow: /thank-you
 
 Sitemap: https://www.lembuildingsurveying.co.uk/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -49,6 +49,7 @@
   <url><loc>https://www.lembuildingsurveying.co.uk/level-3</loc><lastmod>2025-09-20</lastmod></url>
   <url><loc>https://www.lembuildingsurveying.co.uk/local-surveys</loc><lastmod>2025-09-20</lastmod></url>
   <url><loc>https://www.lembuildingsurveying.co.uk/lower-kinnerton-damp-surveys</loc><lastmod>2025-09-20</lastmod></url>
+  <url><loc>https://www.lembuildingsurveying.co.uk/managing-damp-in-traditional-homes</loc><lastmod>2025-09-20</lastmod></url>
   <url><loc>https://www.lembuildingsurveying.co.uk/marford-damp-surveys</loc><lastmod>2025-09-20</lastmod></url>
   <url><loc>https://www.lembuildingsurveying.co.uk/measured-surveys</loc><lastmod>2025-09-20</lastmod></url>
   <url><loc>https://www.lembuildingsurveying.co.uk/mold-damp-surveys</loc><lastmod>2025-09-20</lastmod></url>
@@ -77,7 +78,6 @@
   <url><loc>https://www.lembuildingsurveying.co.uk/tarvin-damp-surveys</loc><lastmod>2025-09-20</lastmod></url>
   <url><loc>https://www.lembuildingsurveying.co.uk/tattenhall-damp-surveys</loc><lastmod>2025-09-20</lastmod></url>
   <url><loc>https://www.lembuildingsurveying.co.uk/testimonials</loc><lastmod>2025-09-20</lastmod></url>
-  <url><loc>https://www.lembuildingsurveying.co.uk/thank-you</loc><lastmod>2025-09-20</lastmod></url>
   <url><loc>https://www.lembuildingsurveying.co.uk/understanding-rics-home-surveys</loc><lastmod>2025-09-20</lastmod></url>
   <url><loc>https://www.lembuildingsurveying.co.uk/understanding-your-survey-report</loc><lastmod>2025-09-20</lastmod></url>
   <url><loc>https://www.lembuildingsurveying.co.uk/ventilation-assessments</loc><lastmod>2025-09-20</lastmod></url>

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -10,7 +10,7 @@ const pagesDir = path.join(repoRoot, 'src', 'pages');
 const outputPath = path.join(repoRoot, 'public', 'sitemap.xml');
 const areasPath = path.join(repoRoot, 'src', 'data', 'areas.ts');
 
-const skipFiles = new Set(['404.astro']);
+const skipFiles = new Set(['404.astro', 'thank-you.astro']);
 
 const now = new Date().toISOString().slice(0, 10);
 

--- a/src/pages/blog-index.astro
+++ b/src/pages/blog-index.astro
@@ -69,11 +69,11 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         </div>
         <div class="service-card">
           <h2><a href="/understanding-rics-home-surveys">RICS Home Surveys Guide</a></h2>
-          <h2><a href="/managing-damp-in-traditional-homes.html">Managing Damp in Traditional Homes</a></h2>
+          <h2><a href="/managing-damp-in-traditional-homes">Managing Damp in Traditional Homes</a></h2>
           <p>Breathable, chemical-free damp management tailored to Flintshire, Chester and North East Wales.</p>
         </div>
         <div class="service-card">
-          <h2><a href="/understanding-rics-home-surveys.html">RICS Home Surveys Guide</a></h2>
+          <h2><a href="/understanding-rics-home-surveys">RICS Home Surveys Guide</a></h2>
           <p>Understand Levels 1, 2 and 3 and choose the right survey.</p>
         </div>
         <div class="service-card">

--- a/src/pages/level-1.astro
+++ b/src/pages/level-1.astro
@@ -141,6 +141,5 @@ const seo = {
 </section><p>Want to explore more? Browse our <a href="/blog-index">blog articles about RICS Home Surveys</a> for detailed insights and helpful advice.</p><!-- FOOTER --><!-- Load Header via JavaScript -->
   <Fragment slot="body-end">
     <script src="/assets/js/includes.js" defer is:inline></script>
-    <script src="/assets/js/review-schema.js" defer is:inline></script>
   </Fragment>
 </BaseLayout>

--- a/src/pages/level-2.astro
+++ b/src/pages/level-2.astro
@@ -264,7 +264,7 @@ const seo = {
   </section>
   <p>
     Want to explore more? Browse our
-    <a href="../blog-index.html">blog articles about RICS Home Surveys</a> for
+    <a href="/blog-index">blog articles about RICS Home Surveys</a> for
     detailed insights and helpful advice.
   </p>
   <Fragment slot="body-end">

--- a/src/pages/level-3.astro
+++ b/src/pages/level-3.astro
@@ -243,7 +243,7 @@ const seo = {
       </p>
       <p>
         Want to explore more? Browse our
-        <a href="../blog-index.html">blog articles about RICS Home Surveys</a> for
+    <a href="/blog-index">blog articles about RICS Home Surveys</a> for
         detailed insights and helpful advice.
       </p>
       <p>

--- a/src/pages/managing-damp-in-traditional-homes.astro
+++ b/src/pages/managing-damp-in-traditional-homes.astro
@@ -11,7 +11,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     />
     <link
       rel="canonical"
-      href="https://www.lembuildingsurveying.co.uk/managing-damp-in-traditional-homes.html"
+      href="https://www.lembuildingsurveying.co.uk/managing-damp-in-traditional-homes"
     />
   </Fragment>
 
@@ -283,8 +283,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           </p>
           <p>
             For conservation-led support, explore our
-            <a href="/damp-mould-surveys.html">damp &amp; mould surveys</a> and
-            <a href="/damp-timber-surveys.html">timber investigations</a>, or call
+            <a href="/damp-mould-surveys">damp &amp; mould surveys</a> and
+            <a href="/damp-timber-surveys">timber investigations</a>, or call
             <a href="tel:07378732037">07378&nbsp;732037</a> to speak with a surveyor.
           </p>
         </section>

--- a/src/pages/thank-you.astro
+++ b/src/pages/thank-you.astro
@@ -28,7 +28,7 @@ const conversionEventScript = hasConversionSendTo
         <meta content="https://www.lembuildingsurveying.co.uk/thank-you" name="twitter:url">
         <meta content="https://www.lembuildingsurveying.co.uk/logo-sticker.png" name="twitter:image">
         <!-- Prevent this page from being indexed -->
-        <meta content="noindex, nofollow" name="robots">
+        <meta content="noindex" name="robots">
 
   </Fragment>
 
@@ -42,7 +42,7 @@ const conversionEventScript = hasConversionSendTo
         </p>
         <div class="button-group">
           <a href="/rics-home-surveys" class="cta-button">See Survey Levels</a>
-          <a href="/index" class="secondary-button">Return Home</a>
+          <a href="/" class="secondary-button">Return Home</a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- update internal links, canonical tags, and redirects to ensure pages resolve at clean extensionless URLs
- remove the unused review schema loader from the Level 1 survey page and tighten robots controls for the thank-you route
- regenerate the sitemap with only indexable extensionless locations and exclude the thank-you page from future runs

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_b_68cec98c808c83238fc963e8efd99324