### PR TITLE
Remove Netlify rewrites for enquiry and contact pages

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -2,8 +2,6 @@ http://www.lembuildingsurveying.co.uk/*  https://www.lembuildingsurveying.co.uk/
 http://lembuildingsurveying.co.uk/*  https://www.lembuildingsurveying.co.uk/:splat  301
 https://lembuildingsurveying.co.uk/*  https://www.lembuildingsurveying.co.uk/:splat  301
 
-/enquiry  /thank-you  200
-/contact  /thank-you  200
 /thank-you.html  /thank-you  301
 /level-2-or-level-3  /level-2-vs-level-3  301
 /level-2-or-level-3.html  /level-2-vs-level-3  301


### PR DESCRIPTION
## Summary
- remove the Netlify rewrite rules that sent `/enquiry` and `/contact` to `/thank-you`
- leave existing legacy redirects such as `/thank-you.html → /thank-you`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cecf5845688323b9c5141715c16a50