### PR TITLE
Prevent direct redirects to thank-you page

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -2,6 +2,8 @@ http://www.lembuildingsurveying.co.uk/*  https://www.lembuildingsurveying.co.uk/
 http://lembuildingsurveying.co.uk/*  https://www.lembuildingsurveying.co.uk/:splat  301
 https://lembuildingsurveying.co.uk/*  https://www.lembuildingsurveying.co.uk/:splat  301
 
+# Form confirmation pages should only be served after a successful submission.
+# Do not redirect enquiry or contact requests to the thank-you page.
 /thank-you.html  /thank-you  301
 /level-2-or-level-3  /level-2-vs-level-3  301
 /level-2-or-level-3.html  /level-2-vs-level-3  301

--- a/tests/redirects.test.ts
+++ b/tests/redirects.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { expect, test } from 'vitest';
+
+const redirectsPath = resolve(__dirname, '../public/_redirects');
+
+const normalisePath = (input: string) =>
+  input
+    .replace(/^https?:\/\/(www\.)?lembuildingsurveying\.co\.uk/i, '')
+    .replace(/\/+$/, '') || '/';
+
+test('contact and enquiry requests are not rewritten to thank-you', () => {
+  const raw = readFileSync(redirectsPath, 'utf8');
+  const lines = raw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'));
+
+  const disallowedSources = new Set(['/contact', '/enquiry']);
+
+  const offenders = lines.filter((line) => {
+    const [from = '', to = ''] = line.split(/\s+/);
+    const source = normalisePath(from);
+    const target = normalisePath(to);
+
+    return (
+      disallowedSources.has(source) &&
+      (target === '/thank-you' || target === 'thank-you')
+    );
+  });
+
+  expect(offenders).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- document in `public/_redirects` that enquiry and contact must not be rewritten to `/thank-you`
- add a regression test that fails if `_redirects` maps enquiry or contact to the thank-you page

## Testing
- npm run test -- --reporter=basic

------
https://chatgpt.com/codex/tasks/task_b_68ced0e284648323b39fb7bd5584be8d