### PR TITLE
Update hero form redirects to thank-you page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,7 +29,11 @@ const seo = {
         class="quote-form"
         method="POST"
       >
-        <input name="_next" type="hidden" value="/thank-you" />
+        <input
+          name="_next"
+          type="hidden"
+          value="https://www.lembuildingsurveying.co.uk/thank-you"
+        />
         <div class="form-grid">
           <label class="field">Your Name
             <input autocomplete="name" name="name" placeholder="e.g. Jane Smith" required type="text" />

--- a/src/pages/rics-home-surveys.astro
+++ b/src/pages/rics-home-surveys.astro
@@ -90,7 +90,11 @@ const seo = {
             secure your survey date.
           </p>
           <form action="https://formspree.io/f/xzzdqqqz" class="quote-form" method="POST">
-            <input name="_next" type="hidden" value="/thank-you">
+            <input
+              name="_next"
+              type="hidden"
+              value="https://www.lembuildingsurveying.co.uk/thank-you"
+            >
             <div class="form-grid">
               <input name="name" placeholder="Your Name" required="" type="text">
               <input name="email" placeholder="Your Email" required="" type="email">


### PR DESCRIPTION
## Summary
- update the `_next` hidden Formspree field on the homepage hero form to point to the live thank-you URL
- make the same redirect update on the RICS Home Surveys hero form so both point to the absolute on-site thank-you page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68ced426ac208323b082da9463159a10