### PR TITLE
Allow AI crawlers in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,15 @@
+User-agent: GPTBot
+Allow: /
+Disallow:
+
+User-agent: ChatGPT-User
+Allow: /
+Disallow:
+
+User-agent: CCBot
+Allow: /
+Disallow:
+
 User-agent: *
 Allow: /
 Disallow: /thank-you


### PR DESCRIPTION
## Summary
- allow GPTBot, ChatGPT-User, and CCBot to crawl the site by providing dedicated user-agent rules
- keep the thank-you page disallowed for other crawlers while leaving the sitemap reference unchanged

## Testing
- not run (static config change)


------
https://chatgpt.com/codex/tasks/task_b_68ced8019a1c8323834276eeb077e621