### PR TITLE
Remove retired footer accreditations

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -77,11 +77,8 @@ const currentYear = new Date().getFullYear();
         />
       </picture>
       <ul class="small">
-        <li>BSc (Building Surveying) — John Moores University</li>
         <li>AssocRICS (Building Surveying)</li>
         <li>MRPSA</li>
-        <li>RICS</li>
-        <li>RPSA</li>
       </ul>
     </section>
 


### PR DESCRIPTION
## Summary
- remove outdated accreditation list items from the footer to match requested credentials

## Testing
- npm run build *(fails: cssnano missing in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ceea7116388323b76a31ca31806882