### PR TITLE
Add damp and mould practical guide blog post

### DIFF
--- a/src/pages/blog/damp-mould-practical-guide.mdx
+++ b/src/pages/blog/damp-mould-practical-guide.mdx
@@ -1,0 +1,121 @@
+---
+title: "Damp and Mould: The Practical Guide (UK)"
+description: "Causes, proper diagnosis, effective remedial works, and current legal duties — with an evidence-led approach."
+publishDate: 2025-09-20
+author: "LEM Building Surveying Ltd"
+image: "/images/blog/practical-damp-guide.webp"
+---
+
+<article itemscope itemtype="https://schema.org/Article">
+  <header>
+    <h1 itemprop="headline">Damp and Mould: The Practical Guide (UK)</h1>
+    <p>
+      <time datetime="2025-09-20" itemprop="datePublished">September 20, 2025</time>
+      {" "} | By <span itemprop="author">LEM Building Surveying Ltd</span>
+    </p>
+  </header>
+
+  <section itemprop="articleBody">
+    <p>Moisture problems cost money, damage buildings, and harm health; they don’t go away on their own. This article explains the <strong>real causes</strong> of damp and mould, <strong>how to diagnose them properly</strong>, <strong>what effective remedial works look like</strong>, and <strong>where the law now stands</strong>.</p>
+
+    <h2>Why damp and mould matter</h2>
+    <ul>
+      <li><strong>Health:</strong> Damp and mould increase risks of respiratory infections and asthma; children, older adults, and people with existing conditions are more vulnerable. Treat damp and mould as a <strong>health risk</strong>, not a housekeeping issue.</li>
+      <li><strong>Housing standards:</strong> Damp and mould are hazards under HHSRS; the Homes (Fitness for Human Habitation) Act 2018 lets tenants take action if a dwelling is unfit, including because of damp and mould.</li>
+      <li><strong>Culture change:</strong> Official guidance stresses residents should not be blamed; cooking, bathing and drying clothes are normal. Landlords must investigate and fix causes.</li>
+    </ul>
+
+    <h2>The five common causes (and how they look)</h2>
+    <ol>
+      <li><strong>Condensation</strong> — moisture from indoor air condenses on cold surfaces.<br/>Clues: black mould on external corners, window reveals, behind furniture, north-facing rooms, winter bias. Root causes: low surface temperatures, inadequate ventilation or intermittent heating. Managed per <strong>BS 5250:2021</strong>.</li>
+      <li><strong>Penetrating damp</strong> — rainwater through defects: failed pointing, cracked render, porous masonry, defective flashings, blocked/leaking gutters, failed seals, or cavity-wall insulation bridging. Typically localised patches that worsen after rain.</li>
+      <li><strong>Low-level moisture / capillary rise (uncommon)</strong> — often a <em>symptom</em> of bridging or altered fabric. Electrical moisture meters are qualitative; <em>not proof</em>. Confirm true capillary rise only with <strong>BRE Digest 245</strong> (gravimetric) and salts/context.</li>
+      <li><strong>Leaks</strong> — plumbing, wastes, overflows, shower enclosures, flat roofs. Often intermittent/hidden; salts and staining patterns help differentiate.</li>
+      <li><strong>Sub-floor/ground moisture</strong> — high external ground levels, blocked sub-floor vents, or missing membranes allow moisture to bypass defences.</li>
+    </ol>
+
+    <h2>How a competent survey should diagnose damp</h2>
+    <ul>
+      <li><strong>Context & fabric review:</strong> age, construction, alterations, ventilation strategy, heating patterns, thermal bridges (apply BS 5250:2021 principles).</li>
+      <li><strong>Visual & thermal inspection:</strong> map patterns; check rainwater goods, penetrations, junctions, and cold spots.</li>
+      <li><strong>Hygrothermal measurements:</strong> spot/logged temperature & RH; check ventilation flow-rates where relevant.</li>
+      <li><strong>Moisture profiling:</strong> use electrical meters for screening only; confirm suspected capillary rise with <strong>BRE 245 gravimetric sampling</strong> (hygroscopic vs capillary moisture).</li>
+      <li><strong>Salt analysis:</strong> chlorides/nitrates suggest ground salts; sulphates can indicate other sources.</li>
+    </ul>
+    <p><strong>Red flag:</strong> anyone prescribing chemical DPCs from a few meter pokes is guessing, not surveying — exactly what BRE 245 warns against.</p>
+
+    <h2>Fixes that actually work</h2>
+    <h3>Condensation & surface mould</h3>
+    <ul>
+      <li>Increase surface temperatures: insulate cold spots (liners/IBR systems); address thermal bridges.</li>
+      <li>Ventilate consistently: repair/commission extract fans; consider continuous/trickle extract; ensure background inlets; commission systems properly.</li>
+      <li>Control moisture at source: lids on pans; extract during/after bathing; avoid drying clothes indoors where possible, or provide ventilated drying spaces.</li>
+    </ul>
+
+    <h3>Penetrating damp</h3>
+    <p>Repair the envelope: gutters, downpipes, flashings, pointing, sealant; check cavities/insulation for bridging and remove localised slumps where needed.</p>
+
+    <h3>Low-level moisture / capillary rise (only where confirmed)</h3>
+    <ul>
+      <li>Remove bridging: reduce ground levels; clear blocked cavities; cut back plaster/render bridging the DPC line.</li>
+      <li>Only then consider DPC insertion (physical preferred; chemical where appropriate) if testing demonstrates true capillary rise and no effective DPC exists; renew contaminated plaster with an appropriate specification.</li>
+    </ul>
+
+    <h3>Leaks & sub-floor moisture</h3>
+    <p>Fix the leak first; ventilate and dry; inspect concealed voids; reinstate membranes or ventilation.</p>
+
+    <h3>Treating mould safely</h3>
+    <p>Tackle the <em>cause</em> first; then clean. Non-porous surfaces can be washed; soft furnishings and mould-contaminated plaster may need replacing. Prioritise prompt action to reduce exposure.</p>
+
+    <h2>Legal duties (England) — where things stand today</h2>
+    <p><strong>Now:</strong> Landlords must keep homes fit for human habitation; damp and mould can render a property unfit. Tenants can act under the Homes Act 2018. Local authorities assess hazards under HHSRS and can enforce. Guidance instructs landlords to investigate and fix; don’t blame “lifestyle”.</p>
+    <p><strong>From 27 October 2025 (Awaab’s Law, phase 1 – social housing):</strong> Prescribed timescales for investigating and repairing serious hazards — starting with damp and mould — will apply to registered providers of social housing. The rollout is phased; always check the latest GOV.UK guidance.</p>
+    <p><em>Policy evolves: verify current guidance before taking legal decisions.</em></p>
+
+    <h2>Quick myth-busting</h2>
+    <ul>
+      <li><strong>“It’s just condensation.”</strong> Sometimes — but penetration, leaks, bridging and ground moisture are common; mechanisms can coexist. Diagnose before prescribing.</li>
+      <li><strong>“A meter says it’s rising damp.”</strong> Electrical meters are qualitative; you need <strong>BRE 245</strong> gravimetric proof.</li>
+      <li><strong>“Bleach fixes mould.”</strong> It can discolour on hard surfaces but won’t fix porous materials or the underlying moisture problem. Remove the cause and reduce exposure.</li>
+    </ul>
+
+    <h2>What we do on a damp & mould survey</h2>
+    <ul>
+      <li>Evidence-based diagnosis to BS 5250:2021 principles</li>
+      <li>Moisture mapping and targeted BRE-245 sampling where justified</li>
+      <li>Action plan prioritising defect repairs, ventilation commissioning, and realistic behaviour guidance that doesn’t shift blame</li>
+      <li>Clear scope of works for contractors; re-inspection as needed</li>
+    </ul>
+
+    <h2>When to call us</h2>
+    <ul>
+      <li>Recurrent mould despite cleaning</li>
+      <li>Damp patches that worsen after rain</li>
+      <li>Tide-marks/salt banding at low level</li>
+      <li>Musty odours, peeling finishes, or deteriorating plaster</li>
+      <li>Condensation problems after window replacements or insulation works</li>
+    </ul>
+
+    <p><strong>Early diagnosis is cheaper than late repairs — and better for health.</strong> Need a targeted inspection or full moisture survey? <a href="/services/damp-surveys">Book a Damp & Mould Survey →</a></p>
+
+    <h2>References & further reading</h2>
+    <p>Government damp & mould guidance (health and landlord duties); HHSRS and Homes Act; BRE Digest 245; BS 5250:2021; sector updates on Awaab’s Law.</p>
+
+  </section>
+
+     <script type="application/ld+json">
+     {JSON.stringify({
+       "@context":"https://schema.org",
+       "@type":"BlogPosting",
+       "mainEntityOfPage":{"@type":"WebPage","@id":"https://www.lembuildingsurveying.co.uk/blog/damp-mould-practical-guide"},
+       "headline":"Damp and Mould: The Practical Guide (UK)",
+       "description":"Evidence-led causes, diagnosis, fixes and current legal duties for damp and mould.",
+       "image":"https://www.lembuildingsurveying.co.uk/images/blog/practical-damp-guide.webp",
+       "author":{"@type":"Organization","name":"LEM Building Surveying Ltd"},
+       "publisher":{"@type":"Organization","name":"LEM Building Surveying Ltd"},
+       "datePublished":"2025-09-20",
+       "dateModified":"2025-09-20"
+     })}
+     </script>
+
+</article>


### PR DESCRIPTION
## Summary
- add the Damp and Mould: The Practical Guide (UK) article under `src/pages/blog`
- include the provided frontmatter, article copy, and JSON-LD metadata for the new post

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68ceec11ca3483238c34369b6b3669b0