### PR TITLE
Add damp surveys service page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,8 @@
         "linkinator": "^6.1.4",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.38",
+        "prettier": "^3.6.2",
+        "prettier-plugin-astro": "^0.14.1",
         "terser": "^5.31.3",
         "typescript": "^5.5.4",
         "vitest": "^1.6.0"
@@ -9302,8 +9304,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9312,6 +9312,21 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-astro": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-astro/-/prettier-plugin-astro-0.14.1.tgz",
+      "integrity": "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler": "^2.9.1",
+        "prettier": "^3.0.0",
+        "sass-formatter": "^0.7.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/pretty-format": {
@@ -9916,6 +9931,13 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/s.color": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/s.color/-/s.color-0.0.15.tgz",
+      "integrity": "sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -9977,6 +9999,16 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sass-formatter": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/sass-formatter/-/sass-formatter-0.7.9.tgz",
+      "integrity": "sha512-CWZ8XiSim+fJVG0cFLStwDvft1VI7uvXdCNJYXhDvowiv+DsbD1nXLiQ4zrE5UBvj5DWZJ93cwN0NX5PMsr1Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "suf-log": "^2.5.3"
+      }
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -10686,6 +10718,16 @@
       },
       "peerDependencies": {
         "postcss": "^8.4.31"
+      }
+    },
+    "node_modules/suf-log": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/suf-log/-/suf-log-2.5.3.tgz",
+      "integrity": "sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "s.color": "0.0.15"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "linkinator": "^6.1.4",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.38",
+    "prettier": "^3.6.2",
+    "prettier-plugin-astro": "^0.14.1",
     "terser": "^5.31.3",
     "typescript": "^5.5.4",
     "vitest": "^1.6.0"

--- a/src/pages/importance-of-independent-damp-surveys.astro
+++ b/src/pages/importance-of-independent-damp-surveys.astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from '../layouts/BaseLayout.astro';
+import BaseLayout from "../layouts/BaseLayout.astro";
 ---
 
 <BaseLayout>
@@ -9,7 +9,10 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       name="description"
       content="Independent damp and timber surveys deliver impartial advice, uncover hidden moisture problems and save you money. Learn the signs to watch for and when to book a survey."
     />
-    <link rel="canonical" href="https://www.lembuildingsurveying.co.uk/importance-of-independent-damp-surveys" />
+    <link
+      rel="canonical"
+      href="https://www.lembuildingsurveying.co.uk/importance-of-independent-damp-surveys"
+    />
   </Fragment>
 
   <main>
@@ -17,41 +20,54 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       <div class="box-container">
         <h1>Why Independent Damp Surveys Matter</h1>
         <p>
-          Dampness is one of the most common—and costly—issues affecting homes in the UK. If left unchecked it can lead
-          to timber decay, mould growth and structural damage. While some contractors offer free damp inspections,
-          their advice is often tied to selling treatments. Independent damp surveys are different: they provide
-          impartial diagnosis and recommendations so you can make informed decisions about your property.
+          Dampness is one of the most common—and costly—issues affecting homes
+          in the UK. If left unchecked it can lead to timber decay, mould growth
+          and structural damage. While some contractors offer free damp
+          inspections, their advice is often tied to selling treatments.
+          Independent damp surveys are different: they provide impartial
+          diagnosis and recommendations so you can make informed decisions about
+          your property.
         </p>
 
         <section>
           <h2>What Is an Independent Damp Survey?</h2>
           <p>
-            An independent damp survey is a comprehensive moisture assessment carried out by a qualified surveyor with
-            no commercial ties to remedial companies. These impartial surveys examine rising damp, leaks, condensation
-            and timber condition without trying to sell you products. Typical inspections include moisture mapping,
-            timber assessment and identification of defects such as leaks and condensation【387932238012025†screenshot】. The
-            surveyor then compiles an evidence‑based report so you can plan the right repairs.
+            An independent damp survey is a comprehensive moisture assessment
+            carried out by a qualified surveyor with no commercial ties to
+            remedial companies. These impartial surveys examine rising damp,
+            leaks, condensation and timber condition without trying to sell you
+            products. Typical inspections include moisture mapping, timber
+            assessment and identification of defects such as leaks and
+            condensation【387932238012025†screenshot】. The surveyor then
+            compiles an evidence‑based report so you can plan the right repairs.
           </p>
           <ul>
             <li>Detailed moisture mapping and profiling</li>
             <li>Assessment of timber health and wood decay</li>
-            <li>Identification of rising damp, leaks and condensation sources</li>
+            <li>
+              Identification of rising damp, leaks and condensation sources
+            </li>
           </ul>
           <p>
-            Independent surveys differ from contractor‑led inspections because they are unbiased and focused solely on
-            diagnosing the problem, not selling a solution. Surveyors use advanced equipment such as thermal imaging
-            cameras and calibrated moisture meters to locate hidden damp【602971247555921†screenshot】.
+            Independent surveys differ from contractor‑led inspections because
+            they are unbiased and focused solely on diagnosing the problem, not
+            selling a solution. Surveyors use advanced equipment such as thermal
+            imaging cameras and calibrated moisture meters to locate hidden
+            damp【602971247555921†screenshot】.
           </p>
         </section>
 
         <section>
           <h2>Why Choose an Independent Damp Surveyor?</h2>
           <p>
-            There are several reasons to instruct an independent surveyor instead of relying on a contractor’s free
-            assessment. An impartial surveyor provides a transparent appraisal, highlighting genuine issues and helping
-            you avoid unnecessary treatments. Their expertise covers a wide range of damp problems, including rising
-            damp, potential leaks and timber condition【602971247555921†screenshot】. By focusing on fact‑based evaluation,
-            independent surveys protect your investment and ensure you only address real problems.
+            There are several reasons to instruct an independent surveyor
+            instead of relying on a contractor’s free assessment. An impartial
+            surveyor provides a transparent appraisal, highlighting genuine
+            issues and helping you avoid unnecessary treatments. Their expertise
+            covers a wide range of damp problems, including rising damp,
+            potential leaks and timber condition【602971247555921†screenshot】.
+            By focusing on fact‑based evaluation, independent surveys protect
+            your investment and ensure you only address real problems.
           </p>
           <ul>
             <li>Unbiased assessment free from commercial influence</li>
@@ -63,10 +79,12 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         <section>
           <h2>Key Benefits of Independent Damp and Timber Surveys</h2>
           <p>
-            Independent damp and timber surveys offer homeowners and purchasers significant advantages. By identifying
-            underlying moisture issues without bias, they help you maintain your property’s integrity and save money
-            on unnecessary repairs. The surveys provide comprehensive insights into both visible and hidden concerns,
-            ensuring you make informed decisions【885642746133199†screenshot】.
+            Independent damp and timber surveys offer homeowners and purchasers
+            significant advantages. By identifying underlying moisture issues
+            without bias, they help you maintain your property’s integrity and
+            save money on unnecessary repairs. The surveys provide comprehensive
+            insights into both visible and hidden concerns, ensuring you make
+            informed decisions【885642746133199†screenshot】.
           </p>
           <ul>
             <li>Unbiased assessment and practical recommendations</li>
@@ -78,47 +96,62 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         <section>
           <h2>Common Signs of Damp and Timber Issues</h2>
           <p>
-            Early detection is essential to prevent widespread damage. Watch out for a musty odour, visible mould,
-            peeling wallpaper and soft or decaying timber. Other common indicators include stains on ceilings and walls,
-            bubbling paint, mould around windows and crumbling plaster【845641007908221†screenshot】【568257215352298†screenshot】.
-            Acting on these signs quickly can prevent serious structural problems and additional expense.
+            Early detection is essential to prevent widespread damage. Watch out
+            for a musty odour, visible mould, peeling wallpaper and soft or
+            decaying timber. Other common indicators include stains on ceilings
+            and walls, bubbling paint, mould around windows and crumbling
+            plaster【845641007908221†screenshot】【568257215352298†screenshot】.
+            Acting on these signs quickly can prevent serious structural
+            problems and additional expense.
           </p>
         </section>
 
         <section>
           <h2>When to Book an Independent Damp Survey</h2>
           <p>
-            Timing matters. Book a survey if you notice any damp patches or mould, when buying or selling a property,
-            or after events like flooding or heavy rainfall【294623305994936†screenshot】. Older properties are also more
-            susceptible to hidden moisture problems, so proactive inspections are wise. Swift action ensures your
-            building remains in optimal condition.
+            Timing matters. Book a survey if you notice any damp patches or
+            mould, when buying or selling a property, or after events like
+            flooding or heavy rainfall【294623305994936†screenshot】. Older
+            properties are also more susceptible to hidden moisture problems, so
+            proactive inspections are wise. Swift action ensures your building
+            remains in optimal condition.
           </p>
         </section>
 
         <section>
           <h2>What to Expect in a Survey Report</h2>
           <p>
-            A comprehensive damp survey report details the extent and severity of moisture issues, using clear language
-            and supporting evidence. Expect to see moisture readings, identified sources of damp, photographs of
-            affected areas, suggested remedial measures and estimated repair costs【114928288835395†screenshot】. Such
-            thorough documentation gives you the confidence to plan repairs or negotiate with contractors and
-            sellers.
+            A comprehensive damp survey report details the extent and severity
+            of moisture issues, using clear language and supporting evidence.
+            Expect to see moisture readings, identified sources of damp,
+            photographs of affected areas, suggested remedial measures and
+            estimated repair costs【114928288835395†screenshot】. Such thorough
+            documentation gives you the confidence to plan repairs or negotiate
+            with contractors and sellers.
           </p>
         </section>
 
         <section>
           <h2>Conclusion</h2>
           <p>
-            Independent damp surveys provide invaluable protection for your home and investment. By delivering unbiased
-            assessments, they ensure you address only genuine issues and avoid costly mistakes. Whether you’re a
-            homeowner dealing with persistent damp or a buyer seeking peace of mind, an impartial survey is a wise
-            choice.
+            Independent damp surveys provide invaluable protection for your home
+            and investment. By delivering unbiased assessments, they ensure you
+            address only genuine issues and avoid costly mistakes. Whether
+            you’re a homeowner dealing with persistent damp or a buyer seeking
+            peace of mind, an impartial survey is a wise choice.
           </p>
           <p>
             Ready to arrange an inspection? Explore our
-            <a href="/independent-damp-survey-vs-contractor">independent vs contractor comparison</a> and our
-            <a href="/damp-mould-surveys">damp &amp; mould survey services</a> to learn more. You can also call
-            <a href="tel:07378732037">07378&nbsp;732037</a> or <a href="/enquiry">request a quote online</a>.
+            <a href="/independent-damp-survey-vs-contractor"
+              >independent vs contractor comparison</a
+            >, review the dedicated <a href="/services/damp-surveys"
+              >professional damp survey service</a
+            >, and our
+            <a href="/damp-mould-surveys">damp &amp; mould survey services</a> to
+            learn more. You can also call
+            <a href="tel:07378732037">07378&nbsp;732037</a> or <a
+              href="/enquiry">request a quote online</a
+            >.
           </p>
         </section>
       </div>

--- a/src/pages/independent-damp-survey-vs-contractor.astro
+++ b/src/pages/independent-damp-survey-vs-contractor.astro
@@ -1,77 +1,113 @@
 ---
-import BaseLayout from '../layouts/BaseLayout.astro';
+import BaseLayout from "../layouts/BaseLayout.astro";
 ---
 
 <BaseLayout>
   <Fragment slot="head">
     <title>Independent Damp Survey or | LEM Building Surveying</title>
-    <meta content="Learn when to commission an independent damp surveyor instead of a contractor. Compare inspection methods, report quality, costs and the impartial advice you receive." name="description">
-    <meta content="independent damp survey, contractor damp report, damp survey vs damp proof company, impartial moisture assessment" name="keywords">
-    <link href="https://www.lembuildingsurveying.co.uk/independent-damp-survey-vs-contractor" rel="canonical">
-    <meta content="Independent Damp Survey or | LEM Building Surveying" property="og:title">
-    <meta content="Learn when to commission an independent damp surveyor instead of a contractor. Compare inspection methods, report quality, costs and the impartial advice you receive." property="og:description">
-    <meta content="https://www.lembuildingsurveying.co.uk/independent-damp-survey-vs-contractor" property="og:url">
-    <meta content="https://www.lembuildingsurveying.co.uk/logo-sticker.png" property="og:image">
-    <meta content="summary_large_image" name="twitter:card">
-    <meta content="Independent Damp Survey or | LEM Building Surveying" name="twitter:title">
-    <meta content="Learn when to commission an independent damp surveyor instead of a contractor. Compare inspection methods, report quality, costs and the impartial advice you receive." name="twitter:description">
-    <meta content="https://www.lembuildingsurveying.co.uk/independent-damp-survey-vs-contractor" name="twitter:url">
-    <meta content="https://www.lembuildingsurveying.co.uk/logo-sticker.png" name="twitter:image">
+    <meta
+      content="Learn when to commission an independent damp surveyor instead of a contractor. Compare inspection methods, report quality, costs and the impartial advice you receive."
+      name="description"
+    />
+    <meta
+      content="independent damp survey, contractor damp report, damp survey vs damp proof company, impartial moisture assessment"
+      name="keywords"
+    />
+    <link
+      href="https://www.lembuildingsurveying.co.uk/independent-damp-survey-vs-contractor"
+      rel="canonical"
+    />
+    <meta
+      content="Independent Damp Survey or | LEM Building Surveying"
+      property="og:title"
+    />
+    <meta
+      content="Learn when to commission an independent damp surveyor instead of a contractor. Compare inspection methods, report quality, costs and the impartial advice you receive."
+      property="og:description"
+    />
+    <meta
+      content="https://www.lembuildingsurveying.co.uk/independent-damp-survey-vs-contractor"
+      property="og:url"
+    />
+    <meta
+      content="https://www.lembuildingsurveying.co.uk/logo-sticker.png"
+      property="og:image"
+    />
+    <meta content="summary_large_image" name="twitter:card" />
+    <meta
+      content="Independent Damp Survey or | LEM Building Surveying"
+      name="twitter:title"
+    />
+    <meta
+      content="Learn when to commission an independent damp surveyor instead of a contractor. Compare inspection methods, report quality, costs and the impartial advice you receive."
+      name="twitter:description"
+    />
+    <meta
+      content="https://www.lembuildingsurveying.co.uk/independent-damp-survey-vs-contractor"
+      name="twitter:url"
+    />
+    <meta
+      content="https://www.lembuildingsurveying.co.uk/logo-sticker.png"
+      name="twitter:image"
+    />
 
     <script type="application/ld+json" is:inline>
-    {
-      "@context": "https://schema.org",
-      "@type": "FAQPage",
-      "mainEntity": [
-        {
-          "@type": "Question",
-          "name": "Why choose an independent damp surveyor?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "Independent surveyors diagnose the root cause of moisture issues without selling treatments. You receive impartial advice, photographs, moisture profiles and practical recommendations aligned with building pathology rather than a sales pitch."
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "Why choose an independent damp surveyor?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Independent surveyors diagnose the root cause of moisture issues without selling treatments. You receive impartial advice, photographs, moisture profiles and practical recommendations aligned with building pathology rather than a sales pitch."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Do damp contractors provide unbiased reports?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Many contractor reports are free because they are designed to sell chemical damp-proof courses or ventilation products. While some offer useful insight, they usually lack independent verification, calibration records or alternative solutions."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How much does an independent damp survey cost?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Our independent damp and mould surveys typically start from £275+VAT locally. Pricing depends on property size, scope and whether lab testing or follow-up monitoring is required."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Will an independent report satisfy my mortgage lender or insurer?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. Our reports are fully documented with readings, photographs and clear recommendations, making them suitable for lenders, housing associations, local authorities and dispute resolution."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Can you recommend trustworthy contractors after the survey?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Once the cause of damp is confirmed we can advise on the type of specialist you may need—such as roofers, drainage engineers or ventilation installers—and provide questions to ask when sourcing quotes."
+            }
           }
-        },
-        {
-          "@type": "Question",
-          "name": "Do damp contractors provide unbiased reports?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "Many contractor reports are free because they are designed to sell chemical damp-proof courses or ventilation products. While some offer useful insight, they usually lack independent verification, calibration records or alternative solutions."
-          }
-        },
-        {
-          "@type": "Question",
-          "name": "How much does an independent damp survey cost?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "Our independent damp and mould surveys typically start from £275+VAT locally. Pricing depends on property size, scope and whether lab testing or follow-up monitoring is required."
-          }
-        },
-        {
-          "@type": "Question",
-          "name": "Will an independent report satisfy my mortgage lender or insurer?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "Yes. Our reports are fully documented with readings, photographs and clear recommendations, making them suitable for lenders, housing associations, local authorities and dispute resolution."
-          }
-        },
-        {
-          "@type": "Question",
-          "name": "Can you recommend trustworthy contractors after the survey?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "Once the cause of damp is confirmed we can advise on the type of specialist you may need—such as roofers, drainage engineers or ventilation installers—and provide questions to ask when sourcing quotes."
-          }
-        }
-      ]
-    }
+        ]
+      }
     </script>
   </Fragment>
 
   <section class="hero">
     <div class="hero-container">
       <h1>Independent Damp Survey or Contractor Report?</h1>
-      <p>Understand the difference between impartial diagnosis and sales-led inspections so you can resolve moisture problems efficiently.</p>
+      <p>
+        Understand the difference between impartial diagnosis and sales-led
+        inspections so you can resolve moisture problems efficiently.
+      </p>
       <a class="cta-button" href="/enquiry">Book an Independent Survey</a>
     </div>
   </section><section class="service-detail">
@@ -94,94 +130,208 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             </tr>
             <tr>
               <td>Inspection methods</td>
-              <td>Moisture mapping, humidity profiling, ventilation checks, building pathology review</td>
-              <td>Often limited to quick meter readings focused on their products</td>
+              <td
+                >Moisture mapping, humidity profiling, ventilation checks,
+                building pathology review</td
+              >
+              <td
+                >Often limited to quick meter readings focused on their products</td
+              >
             </tr>
             <tr>
               <td>Reporting detail</td>
-              <td>Comprehensive PDF report with evidence, photographs, graphs and maintenance advice</td>
-              <td>Brief quotation sheets or remedial recommendations linked to their services</td>
+              <td
+                >Comprehensive PDF report with evidence, photographs, graphs and
+                maintenance advice</td
+              >
+              <td
+                >Brief quotation sheets or remedial recommendations linked to
+                their services</td
+              >
             </tr>
             <tr>
               <td>Cost structure</td>
               <td>Fee-based service with no incentive to oversell</td>
-              <td>Low or free survey offset by promoting installation packages</td>
+              <td
+                >Low or free survey offset by promoting installation packages</td
+              >
             </tr>
             <tr>
               <td>Best suited to</td>
-              <td>Complex, disputed or recurring damp and mould issues where you need clarity</td>
-              <td>Straightforward maintenance repairs when the cause is already known</td>
+              <td
+                >Complex, disputed or recurring damp and mould issues where you
+                need clarity</td
+              >
+              <td
+                >Straightforward maintenance repairs when the cause is already
+                known</td
+              >
             </tr>
           </tbody>
         </table>
       </div>
       <h2>Why Homeowners Choose Independent Damp Surveys</h2>
       <ul>
-        <li><strong>Evidence-led diagnosis:</strong> Readings are logged, photographed and explained so you understand cause and effect.</li>
-        <li><strong>No chemical bias:</strong> Recommendations focus on ventilation, drainage, insulation and maintenance before invasive treatments.</li>
-        <li><strong>Support for negotiations:</strong> Ideal for buyers or tenants who need neutral documentation to request remedial work.</li>
-        <li><strong>Compliance ready:</strong> Reports meet the expectations of lenders, managing agents and local authorities.</li>
+        <li>
+          <strong>Evidence-led diagnosis:</strong> Readings are logged, photographed
+          and explained so you understand cause and effect.
+        </li>
+        <li>
+          <strong>No chemical bias:</strong> Recommendations focus on ventilation,
+          drainage, insulation and maintenance before invasive treatments.
+        </li>
+        <li>
+          <strong>Support for negotiations:</strong> Ideal for buyers or tenants
+          who need neutral documentation to request remedial work.
+        </li>
+        <li>
+          <strong>Compliance ready:</strong> Reports meet the expectations of lenders,
+          managing agents and local authorities.
+        </li>
       </ul>
-      <p>Independent assessments are particularly valuable when damp has persisted despite previous contractor visits or when you suspect condensation, thermal bridging or lifestyle factors are the real drivers.</p>
+      <p>
+        Independent assessments are particularly valuable when damp has
+        persisted despite previous contractor visits or when you suspect
+        condensation, thermal bridging or lifestyle factors are the real
+        drivers.
+      </p>
       <h2>When a Contractor Inspection Might Be Appropriate</h2>
-      <p>There are situations where bringing in a contractor early can work, especially for urgent repairs:</p>
+      <p>
+        There are situations where bringing in a contractor early can work,
+        especially for urgent repairs:
+      </p>
       <ul>
-        <li><strong>Known maintenance failures:</strong> For example, a leaking gutter or cracked render already confirmed through visual inspection.</li>
-        <li><strong>Simple patch repairs:</strong> When you need a quotation to replace a section of damp-proof course or re-point a wall.</li>
-        <li><strong>Existing warranties:</strong> If previous works are under guarantee you may need the original installer to revisit.</li>
+        <li>
+          <strong>Known maintenance failures:</strong> For example, a leaking gutter
+          or cracked render already confirmed through visual inspection.
+        </li>
+        <li>
+          <strong>Simple patch repairs:</strong> When you need a quotation to replace
+          a section of damp-proof course or re-point a wall.
+        </li>
+        <li>
+          <strong>Existing warranties:</strong> If previous works are under guarantee
+          you may need the original installer to revisit.
+        </li>
       </ul>
-      <p>However, even in these cases an independent report can help you verify the root cause before committing to major expenditure.</p>
+      <p>
+        However, even in these cases an independent report can help you verify
+        the root cause before committing to major expenditure.
+      </p>
       <h2>How Our Independent Damp Survey Works</h2>
       <ol>
-        <li><strong>Briefing call:</strong> We review your concerns, property age, previous works and photographs.</li>
-        <li><strong>On-site assessment:</strong> Using calibrated meters, thermo-hygrometers and thermal imaging where beneficial.</li>
-        <li><strong>Root cause analysis:</strong> Findings are cross-referenced with building design, ventilation, heating and occupancy patterns.</li>
-        <li><strong>Clear reporting:</strong> You receive a digital report with moisture profiles, photographs and prioritised actions.</li>
-        <li><strong>Follow-up support:</strong> We walk you through the conclusions and answer questions for contractors or landlords.</li>
+        <li>
+          <strong>Briefing call:</strong> We review your concerns, property age,
+          previous works and photographs.
+        </li>
+        <li>
+          <strong>On-site assessment:</strong> Using calibrated meters, thermo-hygrometers
+          and thermal imaging where beneficial.
+        </li>
+        <li>
+          <strong>Root cause analysis:</strong> Findings are cross-referenced with
+          building design, ventilation, heating and occupancy patterns.
+        </li>
+        <li>
+          <strong>Clear reporting:</strong> You receive a digital report with moisture
+          profiles, photographs and prioritised actions.
+        </li>
+        <li>
+          <strong>Follow-up support:</strong> We walk you through the conclusions
+          and answer questions for contractors or landlords.
+        </li>
       </ol>
       <h2>Typical Costs &amp; Timescales</h2>
-      <p>Independent damp surveys are a professional service that saves you money by preventing unnecessary treatments:</p>
+      <p>
+        Independent damp surveys are a professional service that saves you money
+        by preventing unnecessary treatments:
+      </p>
       <ul>
-        <li><strong>Local surveys from £275+VAT:</strong> Pricing depends on property size, number of rooms assessed and travel distance.</li>
-        <li><strong>Report delivery within 3–5 working days:</strong> Urgent cases can often be fast-tracked.</li>
-        <li><strong>Optional extras:</strong> Laboratory salt analysis or long-term humidity monitoring can be added if required.</li>
+        <li>
+          <strong>Local surveys from £275+VAT:</strong> Pricing depends on property
+          size, number of rooms assessed and travel distance.
+        </li>
+        <li>
+          <strong>Report delivery within 3–5 working days:</strong> Urgent cases
+          can often be fast-tracked.
+        </li>
+        <li>
+          <strong>Optional extras:</strong> Laboratory salt analysis or long-term
+          humidity monitoring can be added if required.
+        </li>
       </ul>
-      <p>Compare this with the cost of installing chemical DPC injections, replastering or whole-house ventilation systems that may not address the real cause.</p>
+      <p>
+        Compare this with the cost of installing chemical DPC injections,
+        replastering or whole-house ventilation systems that may not address the
+        real cause.
+      </p>
       <h2>Putting the Report into Action</h2>
       <p>After receiving your independent survey you will know:</p>
       <ul>
         <li>Which building elements require repair, upgrade or monitoring.</li>
         <li>The order of priority and the estimated level of urgency.</li>
         <li>What information to give contractors when sourcing quotes.</li>
-        <li>How to adapt ventilation and heating to keep moisture under control.</li>
+        <li>
+          How to adapt ventilation and heating to keep moisture under control.
+        </li>
       </ul>
-      <p>Need a full building inspection too? Explore our <a href="/damp-mould-surveys">damp &amp; mould surveys</a> or <a href="/damp-timber-surveys">damp &amp; timber investigations</a> for lender-approved reporting.</p>
+      <p>
+        Need a full building inspection too? Start with our
+        <a href="/services/damp-surveys">professional damp survey service</a>,
+        explore our
+        <a href="/damp-mould-surveys">damp &amp; mould surveys</a> or
+        <a href="/damp-timber-surveys">damp &amp; timber investigations</a> for lender-approved
+        reporting.
+      </p>
       <div class="cta-section">
         <h2>Speak to an Independent Damp Specialist</h2>
-        <p>Call <a href="tel:07378732037">07378 732 037</a> or request a call-back. We cover Deeside, Chester, Flintshire, Wrexham and surrounding areas.</p>
+        <p>
+          Call <a href="tel:07378732037">07378 732 037</a> or request a call-back.
+          We cover Deeside, Chester, Flintshire, Wrexham and surrounding areas.
+        </p>
         <a class="cta-button" href="/enquiry">Arrange My Damp Survey</a>
       </div>
       <h2>FAQs About Independent Damp Surveys</h2>
       <div class="faq-section">
         <details>
           <summary>Will you recommend specific products or installers?</summary>
-          <p>Our role is to diagnose and advise. We remain independent, but can outline the type of specialist you may need and provide questions to ask before appointing them.</p>
+          <p>
+            Our role is to diagnose and advise. We remain independent, but can
+            outline the type of specialist you may need and provide questions to
+            ask before appointing them.
+          </p>
         </details>
         <details>
           <summary>Can you liaise with my landlord or contractor?</summary>
-          <p>Yes. With your permission we can discuss findings with third parties to ensure remedial actions follow best practice.</p>
+          <p>
+            Yes. With your permission we can discuss findings with third parties
+            to ensure remedial actions follow best practice.
+          </p>
         </details>
         <details>
-          <summary>Do you investigate condensation as well as rising damp?</summary>
-          <p>Absolutely. Condensation, ventilation failures and thermal bridges are among the most common issues we solve. We use humidity profiling and thermal imaging to separate these from true rising damp.</p>
+          <summary
+            >Do you investigate condensation as well as rising damp?</summary
+          >
+          <p>
+            Absolutely. Condensation, ventilation failures and thermal bridges
+            are among the most common issues we solve. We use humidity profiling
+            and thermal imaging to separate these from true rising damp.
+          </p>
         </details>
         <details>
           <summary>Is disruptive testing ever required?</summary>
-          <p>Most surveys are non-invasive. If opening up is necessary we will explain why, outline options and only proceed with your approval.</p>
+          <p>
+            Most surveys are non-invasive. If opening up is necessary we will
+            explain why, outline options and only proceed with your approval.
+          </p>
         </details>
         <details>
           <summary>Do you cover housing disrepair claims?</summary>
-          <p>Yes. Independent damp evidence is frequently requested for disrepair, insurance and legal matters. Our reports include the level of detail required for these cases.</p>
+          <p>
+            Yes. Independent damp evidence is frequently requested for
+            disrepair, insurance and legal matters. Our reports include the
+            level of detail required for these cases.
+          </p>
         </details>
       </div>
     </div>

--- a/src/pages/independent-damp-surveys.astro
+++ b/src/pages/independent-damp-surveys.astro
@@ -1,62 +1,62 @@
 ---
-import BaseLayout from '../layouts/BaseLayout.astro';
-import { createServiceSeo } from '../utils/structuredData';
+import BaseLayout from "../layouts/BaseLayout.astro";
+import { createServiceSeo } from "../utils/structuredData";
 
 const independentDampFaqs = [
   {
-    question: 'Why choose an independent damp surveyor?',
+    question: "Why choose an independent damp surveyor?",
     answer:
-      'Independent surveyors provide unbiased assessments that focus on diagnosing real moisture issues rather than selling treatments. You receive advice that protects your budget and targets the root cause of damp.',
+      "Independent surveyors provide unbiased assessments that focus on diagnosing real moisture issues rather than selling treatments. You receive advice that protects your budget and targets the root cause of damp.",
   },
   {
-    question: 'What equipment is used during the inspection?',
+    question: "What equipment is used during the inspection?",
     answer:
-      'Surveys typically include visual inspections, moisture and humidity readings, borescope checks and thermal imaging where required. This combination helps trace leaks, condensation and timber decay that may be hidden from view.',
+      "Surveys typically include visual inspections, moisture and humidity readings, borescope checks and thermal imaging where required. This combination helps trace leaks, condensation and timber decay that may be hidden from view.",
   },
   {
-    question: 'When should I book an independent damp survey?',
+    question: "When should I book an independent damp survey?",
     answer:
-      'Arrange a survey when buying a property, after leaks or flooding, or whenever you notice damp patches, musty odours or timber deterioration. Early diagnosis prevents costly secondary damage.',
+      "Arrange a survey when buying a property, after leaks or flooding, or whenever you notice damp patches, musty odours or timber deterioration. Early diagnosis prevents costly secondary damage.",
   },
 ];
 
 const description =
-  'Discover how independent damp surveys support Deeside and Chester homes, covering inspection tools, warning signs and the best time to book expert advice.';
+  "Discover how independent damp surveys support Deeside and Chester homes, covering inspection tools, warning signs and the best time to book expert advice.";
 
 const { seo: baseSeo, pageUrl } = createServiceSeo({
-  title: 'Independent Damp Surveys | LEM Building Surveying',
+  title: "Independent Damp Surveys | LEM Building Surveying",
   description,
-  canonicalPath: '/independent-damp-surveys',
-  serviceName: 'Independent Damp Surveys',
+  canonicalPath: "/independent-damp-surveys",
+  serviceName: "Independent Damp Surveys",
   faqs: independentDampFaqs,
   review: {
-    author: 'Buyer in Chester',
-    body: 'The independent damp survey highlighted real issues without pushing treatments and helped us renegotiate confidently.',
+    author: "Buyer in Chester",
+    body: "The independent damp survey highlighted real issues without pushing treatments and helped us renegotiate confidently.",
     ratingValue: 5,
-    datePublished: '2024-05-22',
+    datePublished: "2024-05-22",
   },
 });
 
 const breadcrumbSchema = {
-  '@context': 'https://schema.org',
-  '@type': 'BreadcrumbList',
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
   itemListElement: [
     {
-      '@type': 'ListItem',
+      "@type": "ListItem",
       position: 1,
-      name: 'Home',
-      item: 'https://www.lembuildingsurveying.co.uk/',
+      name: "Home",
+      item: "https://www.lembuildingsurveying.co.uk/",
     },
     {
-      '@type': 'ListItem',
+      "@type": "ListItem",
       position: 2,
-      name: 'Services',
-      item: 'https://www.lembuildingsurveying.co.uk/services',
+      name: "Services",
+      item: "https://www.lembuildingsurveying.co.uk/services",
     },
     {
-      '@type': 'ListItem',
+      "@type": "ListItem",
       position: 3,
-      name: 'Independent Damp Surveys',
+      name: "Independent Damp Surveys",
       item: pageUrl,
     },
   ],
@@ -69,7 +69,6 @@ const seo = {
 ---
 
 <BaseLayout pageId="independent-damp-surveys" seo={seo}>
-
   <main>
     <section class="service-detail">
       <div class="box-container">
@@ -78,28 +77,37 @@ const seo = {
         <section>
           <h2>Understanding the Importance of Independent Damp Surveys</h2>
           <p>
-            Damp issues can wreak havoc on properties, leading to costly repairs and health risks. Independent damp surveys offer
-            a solution by providing unbiased assessments. These surveys are crucial for identifying hidden moisture problems. They
-            help homeowners and buyers make informed decisions.
+            Damp issues can wreak havoc on properties, leading to costly repairs
+            and health risks. Independent damp surveys offer a solution by
+            providing unbiased assessments. These surveys are crucial for
+            identifying hidden moisture problems. They help homeowners and
+            buyers make informed decisions.
           </p>
           <p>
-            Unlike surveys tied to repair companies, independent damp surveys ensure objectivity; they focus solely on assessing
-            the property's condition. This approach prevents unnecessary treatments and misdiagnosis. Homeowners can save money and
-            avoid future headaches. Independent damp surveyors use specialised tools to detect issues not visible to the naked eye.
+            Unlike surveys tied to repair companies, independent damp surveys
+            ensure objectivity; they focus solely on assessing the property's
+            condition. This approach prevents unnecessary treatments and
+            misdiagnosis. Homeowners can save money and avoid future headaches.
+            Independent damp surveyors use specialised tools to detect issues
+            not visible to the naked eye.
           </p>
           <p>
-            For property buyers, these surveys are essential. They reveal potential problems before purchase, safeguarding
-            investments. Understanding the importance of independent damp surveys is key to maintaining a safe, healthy home.
+            For property buyers, these surveys are essential. They reveal
+            potential problems before purchase, safeguarding investments.
+            Understanding the importance of independent damp surveys is key to
+            maintaining a safe, healthy home.
           </p>
         </section>
 
         <section>
           <h2>What Are Independent Damp Surveys?</h2>
           <p>
-            Independent damp surveys examine moisture issues in properties without commercial bias. Conducted by impartial
-            surveyors, they detect damp problems accurately. These surveys differ from those linked to repair firms; they provide
-            objective evaluations focused on identifying real issues, which prevents unnecessary treatments based on misleading
-            findings.
+            Independent damp surveys examine moisture issues in properties
+            without commercial bias. Conducted by impartial surveyors, they
+            detect damp problems accurately. These surveys differ from those
+            linked to repair firms; they provide objective evaluations focused
+            on identifying real issues, which prevents unnecessary treatments
+            based on misleading findings.
           </p>
           <ul>
             <li>Detailed moisture mapping</li>
@@ -107,17 +115,21 @@ const seo = {
             <li>Identification of rising damp, leaks, and condensation</li>
           </ul>
           <p>
-            Surveyors use advanced equipment such as thermal imaging cameras and moisture meters, ensuring thorough inspections. By
-            focusing on fact-based evaluations, they offer homeowners reliable information. With independent damp surveys, you can
-            trust the findings to guide your decisions.
+            Surveyors use advanced equipment such as thermal imaging cameras and
+            moisture meters, ensuring thorough inspections. By focusing on
+            fact-based evaluations, they offer homeowners reliable information.
+            With independent damp surveys, you can trust the findings to guide
+            your decisions.
           </p>
         </section>
 
         <section>
           <h2>Why Choose an Independent Damp Surveyor?</h2>
           <p>
-            Choosing an independent damp surveyor offers several advantages. They provide an unbiased assessment, free from the
-            influence of repair companies. This ensures the advice you receive is honest and purely focused on your best interests.
+            Choosing an independent damp surveyor offers several advantages.
+            They provide an unbiased assessment, free from the influence of
+            repair companies. This ensures the advice you receive is honest and
+            purely focused on your best interests.
           </p>
           <ul>
             <li>Rising damp and its causes</li>
@@ -125,18 +137,22 @@ const seo = {
             <li>Condition and health of timber structures</li>
           </ul>
           <p>
-            Their assessments are thorough and backed by training and certification. This ensures they understand the complexities
-            of property moisture problems. Trusting an independent surveyor helps protect your investment and maintain your
-            property’s health.
+            Their assessments are thorough and backed by training and
+            certification. This ensures they understand the complexities of
+            property moisture problems. Trusting an independent surveyor helps
+            protect your investment and maintain your property’s health.
           </p>
         </section>
 
         <section>
           <h2>Key Benefits of Independent Damp and Timber Surveys</h2>
           <p>
-            The advantages of independent damp and timber surveys are significant. They bring value by identifying underlying
-            issues without bias. Homeowners find these surveys essential for maintaining their property's integrity. An unbiased
-            survey can save you money; misdiagnosis of damp problems often leads to costly, unnecessary repairs.
+            The advantages of independent damp and timber surveys are
+            significant. They bring value by identifying underlying issues
+            without bias. Homeowners find these surveys essential for
+            maintaining their property's integrity. An unbiased survey can save
+            you money; misdiagnosis of damp problems often leads to costly,
+            unnecessary repairs.
           </p>
           <ul>
             <li>Unbiased assessment and recommendations</li>
@@ -149,15 +165,19 @@ const seo = {
               alt="Property Damp Inspection"
               loading="lazy"
             />
-            <figcaption>Photo by Fabian Kleiser (unsplash.com/@fabiankleiser)</figcaption>
+            <figcaption>
+              Photo by Fabian Kleiser (unsplash.com/@fabiankleiser)
+            </figcaption>
           </figure>
         </section>
 
         <section>
           <h2>How Do Independent Damp Survey Services Work?</h2>
           <p>
-            Independent damp survey services involve a systematic process to ensure thorough inspections. These surveys use
-            precise, advanced tools for accurate results, and are conducted by highly trained professionals for unbiased outcomes.
+            Independent damp survey services involve a systematic process to
+            ensure thorough inspections. These surveys use precise, advanced
+            tools for accurate results, and are conducted by highly trained
+            professionals for unbiased outcomes.
           </p>
           <ol>
             <li>Initial property walkthrough</li>
@@ -170,16 +190,20 @@ const seo = {
               alt="Surveyor at Work"
               loading="lazy"
             />
-            <figcaption>Photo by Samuel Daniel (unsplash.com/@samda)</figcaption>
+            <figcaption>
+              Photo by Samuel Daniel (unsplash.com/@samda)
+            </figcaption>
           </figure>
         </section>
 
         <section>
           <h2>Common Signs of Damp and Timber Issues</h2>
           <p>
-            Identifying damp and timber issues early can prevent extensive damage. Common indicators include a musty odour, visible
-            mould, or peeling wallpaper. You may also notice discoloured patches on walls, signalling moisture issues. Timber issues
-            may cause wood to feel soft or appear decayed.
+            Identifying damp and timber issues early can prevent extensive
+            damage. Common indicators include a musty odour, visible mould, or
+            peeling wallpaper. You may also notice discoloured patches on walls,
+            signalling moisture issues. Timber issues may cause wood to feel
+            soft or appear decayed.
           </p>
           <ul>
             <li>Stains or patches on ceilings and walls</li>
@@ -193,15 +217,18 @@ const seo = {
               alt="Signs of Damp on Wall"
               loading="lazy"
             />
-            <figcaption>Photo by Brett Jordan (unsplash.com/@brett_jordan)</figcaption>
+            <figcaption>
+              Photo by Brett Jordan (unsplash.com/@brett_jordan)
+            </figcaption>
           </figure>
         </section>
 
         <section>
           <h2>When Should You Book an Independent Damp Survey?</h2>
           <p>
-            Timing is essential when it comes to damp surveys. Ideally, book a survey if you notice any signs of dampness or before
-            buying a property. Consider booking a survey:
+            Timing is essential when it comes to damp surveys. Ideally, book a
+            survey if you notice any signs of dampness or before buying a
+            property. Consider booking a survey:
           </p>
           <ul>
             <li>When buying or selling a property</li>
@@ -209,16 +236,18 @@ const seo = {
             <li>After a flood or heavy rainfall</li>
           </ul>
           <p>
-            These surveys are also crucial for older properties, as they are more susceptible to hidden issues. Acting swiftly
-            ensures your property remains in optimal condition.
+            These surveys are also crucial for older properties, as they are
+            more susceptible to hidden issues. Acting swiftly ensures your
+            property remains in optimal condition.
           </p>
         </section>
 
         <section>
           <h2>What to Expect in a Damp Survey Report</h2>
           <p>
-            A comprehensive damp survey report provides detailed findings. It highlights the extent and severity of identified
-            issues. Typically, a damp survey report may contain:
+            A comprehensive damp survey report provides detailed findings. It
+            highlights the extent and severity of identified issues. Typically,
+            a damp survey report may contain:
           </p>
           <ul>
             <li>Detailed moisture readings</li>
@@ -228,17 +257,28 @@ const seo = {
             <li>Estimated repair costs</li>
           </ul>
           <p>
-            These reports are essential for understanding your property's needs and offer a clear direction for addressing damp
-            issues promptly. An independent report ensures you make informed decisions without bias.
+            These reports are essential for understanding your property's needs
+            and offer a clear direction for addressing damp issues promptly. An
+            independent report ensures you make informed decisions without bias.
           </p>
         </section>
 
         <section>
-          <h2>Conclusion: Protecting Your Property with Independent Damp Surveys</h2>
+          <h2>
+            Conclusion: Protecting Your Property with Independent Damp Surveys
+          </h2>
           <p>
-            Independent damp surveys are invaluable for safeguarding your investment. They provide an unbiased assessment,
-            ensuring you address only real issues. Regular surveys can identify potential damp problems early on, offering peace of
-            mind and a safe living environment. Investing in independent damp surveys is wise for every homeowner.
+            Independent damp surveys are invaluable for safeguarding your
+            investment. They provide an unbiased assessment, ensuring you
+            address only real issues. Regular surveys can identify potential
+            damp problems early on, offering peace of mind and a safe living
+            environment. Investing in independent damp surveys is wise for every
+            homeowner.
+          </p>
+          <p>
+            When you are ready to book, explore our
+            <a href="/services/damp-surveys">professional damp survey service</a
+            > to see what’s included and how we support you after the report.
           </p>
         </section>
       </div>

--- a/src/pages/managing-damp-in-traditional-homes.astro
+++ b/src/pages/managing-damp-in-traditional-homes.astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from '../layouts/BaseLayout.astro';
+import BaseLayout from "../layouts/BaseLayout.astro";
 ---
 
 <BaseLayout>
@@ -18,223 +18,301 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <main>
     <section class="service-detail">
       <div class="box-container">
-        <h1>Managing Damp in Traditional Homes Flintshire, Chester, Cheshire, and North East Wales</h1>
+        <h1>
+          Managing Damp in Traditional Homes Flintshire, Chester, Cheshire, and
+          North East Wales
+        </h1>
         <p>
-          Traditional cottages, townhouses and farmsteads give Flintshire, Chester, Cheshire and North East Wales their
-          distinctive character. Yet their lime mortars, timber frames and solid masonry behave very differently from
-          modern cavity-wall construction. When moisture problems appear, quick-fix chemical injections often make
-          matters worse. A sympathetic, building-led approach keeps historic fabric dry without stripping away the
-          qualities that make these homes special.
+          Traditional cottages, townhouses and farmsteads give Flintshire,
+          Chester, Cheshire and North East Wales their distinctive character.
+          Yet their lime mortars, timber frames and solid masonry behave very
+          differently from modern cavity-wall construction. When moisture
+          problems appear, quick-fix chemical injections often make matters
+          worse. A sympathetic, building-led approach keeps historic fabric dry
+          without stripping away the qualities that make these homes special.
         </p>
         <p>
-          This guide explains how damp develops in older buildings, why chemical damp proof courses rarely succeed, and
-          the natural management methods that protect both your property and its heritage value. Whether you own a
-          Victorian terrace in Chester or a rural cottage near Mold, these principles will help you create a healthier
-          living environment.
+          This guide explains how damp develops in older buildings, why chemical
+          damp proof courses rarely succeed, and the natural management methods
+          that protect both your property and its heritage value. Whether you
+          own a Victorian terrace in Chester or a rural cottage near Mold, these
+          principles will help you create a healthier living environment.
         </p>
 
         <section>
           <h2>Understanding Damp in Historic Buildings</h2>
           <p>
-            Damp is one of the most frequently reported issues in period homes. Recognising how moisture moves through
-            historic materials is the first step towards lasting solutions that respect the property’s fabric.
+            Damp is one of the most frequently reported issues in period homes.
+            Recognising how moisture moves through historic materials is the
+            first step towards lasting solutions that respect the property’s
+            fabric.
           </p>
           <h3>Why Traditional Homes Behave Differently from Modern Houses</h3>
           <p>
-            Pre‑1919 buildings typically use breathable materials such as lime mortar, porous stone and soft brick. These
-            components allow moisture to evaporate naturally, balancing internal humidity with external conditions.
-            Modern waterproof coatings, cement renders and injected barriers disrupt that balance by sealing moisture in
-            the wall. The trapped water leads to salt contamination, flaking plaster and decaying timber. Successful damp
-            management therefore relies on maintaining breathability rather than blocking moisture pathways.
+            Pre‑1919 buildings typically use breathable materials such as lime
+            mortar, porous stone and soft brick. These components allow moisture
+            to evaporate naturally, balancing internal humidity with external
+            conditions. Modern waterproof coatings, cement renders and injected
+            barriers disrupt that balance by sealing moisture in the wall. The
+            trapped water leads to salt contamination, flaking plaster and
+            decaying timber. Successful damp management therefore relies on
+            maintaining breathability rather than blocking moisture pathways.
           </p>
           <h3>Common Signs of Damp in Period Properties</h3>
           <p>
-            Damp problems often develop gradually. Early intervention prevents costly repairs and protects interior
-            finishes. Look out for:
+            Damp problems often develop gradually. Early intervention prevents
+            costly repairs and protects interior finishes. Look out for:
           </p>
           <ul>
             <li>Blistering or flaking paint and plaster</li>
             <li>Horizontal tide marks or salt crystals on wall surfaces</li>
             <li>Musty odours in cellars, cupboards and voids</li>
-            <li>Condensation on cold external walls or original sash windows</li>
-            <li>Timber skirtings, joists or lintels becoming soft, brittle or discoloured</li>
+            <li>
+              Condensation on cold external walls or original sash windows
+            </li>
+            <li>
+              Timber skirtings, joists or lintels becoming soft, brittle or
+              discoloured
+            </li>
           </ul>
         </section>
 
         <section>
           <h2>Causes of Damp in Traditional Homes</h2>
           <p>
-            No single damp problem is the same. Diagnosing the underlying cause ensures you invest in repairs that
-            actually work.
+            No single damp problem is the same. Diagnosing the underlying cause
+            ensures you invest in repairs that actually work.
           </p>
           <h3>Rising Damp: Myths and Realities</h3>
           <p>
-            True rising damp—groundwater travelling up through a wall by capillary action—is much rarer than often
-            claimed. Misdiagnosis leads to expensive chemical treatments that fail because the real culprit was a blocked
-            drain, leaking downpipe or internal condensation. Surveyors experienced with heritage buildings focus on the
-            whole moisture profile, not just isolated meter readings.
+            True rising damp—groundwater travelling up through a wall by
+            capillary action—is much rarer than often claimed. Misdiagnosis
+            leads to expensive chemical treatments that fail because the real
+            culprit was a blocked drain, leaking downpipe or internal
+            condensation. Surveyors experienced with heritage buildings focus on
+            the whole moisture profile, not just isolated meter readings.
           </p>
           <h3>Penetrating Damp from Weather and Rainfall</h3>
           <p>
-            Flintshire and Cheshire receive significant rainfall driven by prevailing westerly winds. Saturated external
-            walls, failed pointing or cracked render can allow rain to migrate indoors. Breathable lime pointing and
-            well-maintained limewash encourage moisture to escape again, whereas cement-based finishes trap it in the
-            masonry.
+            Flintshire and Cheshire receive significant rainfall driven by
+            prevailing westerly winds. Saturated external walls, failed pointing
+            or cracked render can allow rain to migrate indoors. Breathable lime
+            pointing and well-maintained limewash encourage moisture to escape
+            again, whereas cement-based finishes trap it in the masonry.
           </p>
           <h3>Condensation and Poor Ventilation</h3>
           <p>
-            Tightly sealed windows, blocked chimneys and modern living habits produce excess humidity. When that moisture
-            meets cold, uninsulated walls it condenses as droplets or black mould. Restoring natural ventilation routes
-            and gently heating rooms reduces the risk without relying on chemical additives or vapour-impermeable paints.
+            Tightly sealed windows, blocked chimneys and modern living habits
+            produce excess humidity. When that moisture meets cold, uninsulated
+            walls it condenses as droplets or black mould. Restoring natural
+            ventilation routes and gently heating rooms reduces the risk without
+            relying on chemical additives or vapour-impermeable paints.
           </p>
           <h3>Groundwater and Drainage Issues</h3>
           <p>
-            High external ground levels, compacted flowerbeds and damaged gullies can direct water against a wall. Over
-            time, this causes persistent damp patches at the base of interior walls. Lowering soil levels, clearing debris
-            from drains and diverting rainwater away from the building break the cycle of saturation.
+            High external ground levels, compacted flowerbeds and damaged
+            gullies can direct water against a wall. Over time, this causes
+            persistent damp patches at the base of interior walls. Lowering soil
+            levels, clearing debris from drains and diverting rainwater away
+            from the building break the cycle of saturation.
           </p>
         </section>
 
         <section>
           <h2>The Problem with Chemical Damp Proof Courses</h2>
           <p>
-            Chemical damp proof courses promise a quick fix, yet traditional walls seldom respond well to them. Before
-            committing to injections or waterproof coatings, consider the limitations.
+            Chemical damp proof courses promise a quick fix, yet traditional
+            walls seldom respond well to them. Before committing to injections
+            or waterproof coatings, consider the limitations.
           </p>
           <figure>
-            <img src="/breathable-vs-chemical.png" alt="Comparison of breathable and chemical damp treatments" loading="lazy" />
-            <figcaption>Breathable materials manage moisture naturally, unlike impermeable chemical barriers.</figcaption>
+            <img
+              src="/breathable-vs-chemical.png"
+              alt="Comparison of breathable and chemical damp treatments"
+              loading="lazy"
+            />
+            <figcaption>
+              Breathable materials manage moisture naturally, unlike impermeable
+              chemical barriers.
+            </figcaption>
           </figure>
           <h3>Why They Fail in Traditional Walls</h3>
           <p>
-            Random stone rubble cores, wide mortar joints and voids make it impossible for chemical injections to create a
-            continuous barrier. Fluids follow the path of least resistance and leave untreated gaps. Moisture simply finds
-            another route, leaving homeowners out of pocket with damp still present.
+            Random stone rubble cores, wide mortar joints and voids make it
+            impossible for chemical injections to create a continuous barrier.
+            Fluids follow the path of least resistance and leave untreated gaps.
+            Moisture simply finds another route, leaving homeowners out of
+            pocket with damp still present.
           </p>
           <h3>Potential Damage to Heritage Materials</h3>
           <p>
-            Injected creams and waterproof slurries seal the surface of lime plaster and stone. As the wall dries unevenly,
-            salts crystallise beneath the hardened layer and force it to delaminate. Timber embedded in walls can also
-            decay faster when moisture becomes trapped around it.
+            Injected creams and waterproof slurries seal the surface of lime
+            plaster and stone. As the wall dries unevenly, salts crystallise
+            beneath the hardened layer and force it to delaminate. Timber
+            embedded in walls can also decay faster when moisture becomes
+            trapped around it.
           </p>
           <h3>The Cost vs. Effectiveness Debate</h3>
           <p>
-            Chemical systems often cost thousands of pounds yet rarely address the root cause of moisture. Investing the
-            same budget in roof repairs, drainage improvements and breathable finishes delivers proven, long-term
-            benefits with far less disruption.
+            Chemical systems often cost thousands of pounds yet rarely address
+            the root cause of moisture. Investing the same budget in roof
+            repairs, drainage improvements and breathable finishes delivers
+            proven, long-term benefits with far less disruption.
           </p>
         </section>
 
         <section>
           <h2>Natural and Sympathetic Damp Management Methods</h2>
           <p>
-            Traditional homes respond best to holistic solutions that work with the building’s fabric rather than against
-            it. The following strategies respect conservation principles while keeping interiors comfortable.
+            Traditional homes respond best to holistic solutions that work with
+            the building’s fabric rather than against it. The following
+            strategies respect conservation principles while keeping interiors
+            comfortable.
           </p>
           <h3>Improving Natural Ventilation</h3>
           <p>
-            Encourage airflow by unsealing redundant fireplaces, fitting discreet air bricks and ensuring windows can be
-            safely opened. Mechanical extract fans in kitchens and bathrooms should discharge outdoors, not into roof
-            voids. These measures expel humid air before it condenses on cooler surfaces.
+            Encourage airflow by unsealing redundant fireplaces, fitting
+            discreet air bricks and ensuring windows can be safely opened.
+            Mechanical extract fans in kitchens and bathrooms should discharge
+            outdoors, not into roof voids. These measures expel humid air before
+            it condenses on cooler surfaces.
           </p>
           <h3>Breathable Plasters and Lime Renders</h3>
           <p>
-            Replace cement-based plasters with lime plaster or hemp-lime mixes that buffer humidity. A breathable finish
-            allows moisture to evaporate evenly, preventing salt blooms and blistering.
+            Replace cement-based plasters with lime plaster or hemp-lime mixes
+            that buffer humidity. A breathable finish allows moisture to
+            evaporate evenly, preventing salt blooms and blistering.
           </p>
           <figure>
-            <img src="/lime-finished-interior.png" alt="Lime plaster finish inside a traditional property" loading="lazy" />
-            <figcaption>Lime-based plasters support the natural breathability of historic walls.</figcaption>
+            <img
+              src="/lime-finished-interior.png"
+              alt="Lime plaster finish inside a traditional property"
+              loading="lazy"
+            />
+            <figcaption>
+              Lime-based plasters support the natural breathability of historic
+              walls.
+            </figcaption>
           </figure>
           <h3>Managing Ground Levels and External Drainage</h3>
           <p>
-            Check that soil, paving and decking sit at least 150mm below internal floor level. Installing land drains or
-            French drains where appropriate keeps foundations drier. Redirect downpipes into soakaways or drainage
-            systems that can handle heavy North Wales rainfall.
+            Check that soil, paving and decking sit at least 150mm below
+            internal floor level. Installing land drains or French drains where
+            appropriate keeps foundations drier. Redirect downpipes into
+            soakaways or drainage systems that can handle heavy North Wales
+            rainfall.
           </p>
           <h3>Roof, Gutter, and Rainwater Maintenance</h3>
           <p>
-            Clean gutters twice a year, repair leaking joints and ensure downpipes discharge freely. Replace cracked
-            slates, slipped tiles and defective lead flashing promptly so that penetrating rainwater never reaches the
-            internal structure.
+            Clean gutters twice a year, repair leaking joints and ensure
+            downpipes discharge freely. Replace cracked slates, slipped tiles
+            and defective lead flashing promptly so that penetrating rainwater
+            never reaches the internal structure.
           </p>
           <figure>
-            <img src="/clearing-gutters.png" alt="Surveyor clearing gutters on a traditional home" loading="lazy" />
-            <figcaption>Simple maintenance tasks like gutter clearing prevent rainwater from saturating walls.</figcaption>
+            <img
+              src="/clearing-gutters.png"
+              alt="Surveyor clearing gutters on a traditional home"
+              loading="lazy"
+            />
+            <figcaption>
+              Simple maintenance tasks like gutter clearing prevent rainwater
+              from saturating walls.
+            </figcaption>
           </figure>
           <h3>Timber Preservation without Harsh Chemicals</h3>
           <p>
-            Most fungal decay and wood-boring insects thrive only in damp conditions. By improving ventilation and
-            controlling moisture, you remove the need for aggressive chemical treatments. Use targeted repairs, such as
-            splicing in new timber or applying boron rods, only where structural integrity is compromised.
+            Most fungal decay and wood-boring insects thrive only in damp
+            conditions. By improving ventilation and controlling moisture, you
+            remove the need for aggressive chemical treatments. Use targeted
+            repairs, such as splicing in new timber or applying boron rods, only
+            where structural integrity is compromised.
           </p>
         </section>
 
         <section>
           <h2>Case Studies: Damp Solutions in Flintshire and Cheshire</h2>
           <p>
-            Local projects show how sympathetic methods outperform blanket chemical treatments.
+            Local projects show how sympathetic methods outperform blanket
+            chemical treatments.
           </p>
           <h3>Restoring a Flintshire Cottage</h3>
           <p>
-            A stone cottage near Mold suffered from saturated walls after decades beneath cement render. Removing the
-            render, re-pointing with lime mortar and reopening the original inglenook fireplace allowed the walls to dry
-            naturally within months.
+            A stone cottage near Mold suffered from saturated walls after
+            decades beneath cement render. Removing the render, re-pointing with
+            lime mortar and reopening the original inglenook fireplace allowed
+            the walls to dry naturally within months.
           </p>
           <figure>
-            <img src="/flintshire-cottage.png" alt="Traditional Flintshire cottage with lime mortar repairs" loading="lazy" />
-            <figcaption>Lime repointing and restored ventilation revived this Flintshire cottage.</figcaption>
+            <img
+              src="/flintshire-cottage.png"
+              alt="Traditional Flintshire cottage with lime mortar repairs"
+              loading="lazy"
+            />
+            <figcaption>
+              Lime repointing and restored ventilation revived this Flintshire
+              cottage.
+            </figcaption>
           </figure>
           <h3>Chester Townhouse Damp Management</h3>
           <p>
-            A Georgian townhouse in Chester had been misdiagnosed with rising damp. Instead of injections, the owner
-            lowered external ground levels, repaired cast-iron gutters and replastered with lime. Moisture readings fell
-            steadily over the following year without any chemical intervention.
+            A Georgian townhouse in Chester had been misdiagnosed with rising
+            damp. Instead of injections, the owner lowered external ground
+            levels, repaired cast-iron gutters and replastered with lime.
+            Moisture readings fell steadily over the following year without any
+            chemical intervention.
           </p>
           <h3>Rural Cheshire Farmhouse Solutions</h3>
           <p>
-            On a Nantwich-area farmhouse, new land drains and breathable limecrete floors replaced impermeable concrete.
-            Coupled with controlled ventilation, these upgrades eliminated condensation and preserved the original oak
-            beams.
+            On a Nantwich-area farmhouse, new land drains and breathable
+            limecrete floors replaced impermeable concrete. Coupled with
+            controlled ventilation, these upgrades eliminated condensation and
+            preserved the original oak beams.
           </p>
         </section>
 
         <section>
           <h2>Preventive Maintenance for Traditional Homes</h2>
           <p>
-            Routine maintenance keeps moisture at bay and protects valuable materials. Scheduling small tasks throughout
-            the year is far cheaper than tackling extensive damp damage later.
+            Routine maintenance keeps moisture at bay and protects valuable
+            materials. Scheduling small tasks throughout the year is far cheaper
+            than tackling extensive damp damage later.
           </p>
           <h3>Seasonal Checks and Repairs</h3>
           <p>
-            Inspect roofs, flashings and rainwater goods every spring and autumn. Clear vegetation away from walls, remove
-            debris from drains and repair pointing before winter storms expose weaknesses.
+            Inspect roofs, flashings and rainwater goods every spring and
+            autumn. Clear vegetation away from walls, remove debris from drains
+            and repair pointing before winter storms expose weaknesses.
           </p>
           <h3>Regular Monitoring and Moisture Surveys</h3>
           <p>
-            Track humidity with inexpensive sensors and consider professional moisture surveys when symptoms persist.
-            Independent damp specialists use calibrated instruments to differentiate between surface condensation and
-            deeper structural problems, ensuring any remedial work targets the true cause.
+            Track humidity with inexpensive sensors and consider professional
+            moisture surveys when symptoms persist. Independent damp specialists
+            use calibrated instruments to differentiate between surface
+            condensation and deeper structural problems, ensuring any remedial
+            work targets the true cause.
           </p>
         </section>
 
         <section>
           <h2>Local Expertise and Conservation Principles</h2>
           <p>
-            Heritage buildings benefit from guidance tailored to regional climate patterns and traditional construction
-            methods.
+            Heritage buildings benefit from guidance tailored to regional
+            climate patterns and traditional construction methods.
           </p>
           <h3>Why Local Climate Knowledge Matters</h3>
           <p>
-            North East Wales experiences driving rain and prevailing winds that can overwhelm generic damp solutions.
-            Local specialists understand how weather patterns affect exposed gables, chimneys and valley gutters, enabling
-            them to specify durable, site-specific repairs.
+            North East Wales experiences driving rain and prevailing winds that
+            can overwhelm generic damp solutions. Local specialists understand
+            how weather patterns affect exposed gables, chimneys and valley
+            gutters, enabling them to specify durable, site-specific repairs.
           </p>
           <h3>Heritage Building Specialists in North East Wales</h3>
           <p>
-            Conservation-accredited surveyors, lime plasterers and joiners across the region provide sympathetic services.
-            Their expertise ensures repairs comply with planning requirements and safeguard the historic significance of
-            your property.
+            Conservation-accredited surveyors, lime plasterers and joiners
+            across the region provide sympathetic services. Their expertise
+            ensures repairs comply with planning requirements and safeguard the
+            historic significance of your property.
           </p>
         </section>
 
@@ -242,47 +320,58 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <h2>FAQs on Managing Damp in Traditional Homes</h2>
           <h3>Is rising damp real in old houses?</h3>
           <p>
-            True rising damp can occur but is rare. Most cases labelled as rising damp stem from defective maintenance,
-            high external ground levels or condensation. Independent surveys help confirm the real cause before you invest
-            in treatments.
+            True rising damp can occur but is rare. Most cases labelled as
+            rising damp stem from defective maintenance, high external ground
+            levels or condensation. Independent surveys help confirm the real
+            cause before you invest in treatments.
           </p>
-          <h3>Should I use a chemical damp proof course in my period property?</h3>
+          <h3>
+            Should I use a chemical damp proof course in my period property?
+          </h3>
           <p>
-            Chemical damp proof courses are seldom compatible with breathable walls and can trap moisture inside. It is
-            better to address ventilation, drainage and material compatibility first.
+            Chemical damp proof courses are seldom compatible with breathable
+            walls and can trap moisture inside. It is better to address
+            ventilation, drainage and material compatibility first.
           </p>
           <h3>What’s the best plaster for damp walls?</h3>
           <p>
-            Lime plaster is the preferred option for traditional buildings. Its vapour permeability allows walls to dry
-            evenly, preventing salt damage and blistering paint.
+            Lime plaster is the preferred option for traditional buildings. Its
+            vapour permeability allows walls to dry evenly, preventing salt
+            damage and blistering paint.
           </p>
           <h3>How can I stop condensation in a cottage?</h3>
           <p>
-            Increase ventilation by opening windows, reinstating air bricks and keeping chimneys ventilated. Combine these
-            steps with balanced heating and extractor fans that vent outside.
+            Increase ventilation by opening windows, reinstating air bricks and
+            keeping chimneys ventilated. Combine these steps with balanced
+            heating and extractor fans that vent outside.
           </p>
           <h3>Are dehumidifiers a good solution?</h3>
           <p>
-            Dehumidifiers provide short-term relief but do not remove the source of moisture. Use them alongside
-            structural repairs and ventilation improvements rather than as a standalone cure.
+            Dehumidifiers provide short-term relief but do not remove the source
+            of moisture. Use them alongside structural repairs and ventilation
+            improvements rather than as a standalone cure.
           </p>
           <h3>How often should I check gutters and roofs?</h3>
           <p>
-            Inspect gutters, downpipes and roof coverings at least twice a year—typically in spring and autumn—and after
-            severe storms to ensure rainwater is safely diverted away from the building.
+            Inspect gutters, downpipes and roof coverings at least twice a
+            year—typically in spring and autumn—and after severe storms to
+            ensure rainwater is safely diverted away from the building.
           </p>
         </section>
 
         <section>
           <h2>Conclusion: A Healthier Approach to Damp in Historic Homes</h2>
           <p>
-            Managing damp in traditional homes across Flintshire, Chester, Cheshire and North East Wales means working with
-            the building, not against it. By prioritising breathable materials, effective drainage and good ventilation,
-            you can protect both the structure and the wellbeing of its occupants without resorting to invasive chemical
+            Managing damp in traditional homes across Flintshire, Chester,
+            Cheshire and North East Wales means working with the building, not
+            against it. By prioritising breathable materials, effective drainage
+            and good ventilation, you can protect both the structure and the
+            wellbeing of its occupants without resorting to invasive chemical
             treatments.
           </p>
           <p>
             For conservation-led support, explore our
+            <a href="/services/damp-surveys">dedicated damp survey service</a>,
             <a href="/damp-mould-surveys">damp &amp; mould surveys</a> and
             <a href="/damp-timber-surveys">timber investigations</a>, or call
             <a href="tel:07378732037">07378&nbsp;732037</a> to speak with a surveyor.

--- a/src/pages/services/damp-surveys.astro
+++ b/src/pages/services/damp-surveys.astro
@@ -1,0 +1,134 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+
+export const title =
+  "Damp Surveys in North Wales & Cheshire | LEM Building Surveying";
+export const description =
+  "Professional, evidence-led damp & mould surveys by RICS-accredited surveyors. Serving Chester, Wrexham, Flintshire and nearby towns.";
+
+const canonicalPath = "/services/damp-surveys";
+const canonicalUrl = `https://www.lembuildingsurveying.co.uk${canonicalPath}`;
+
+const seo = {
+  title,
+  description,
+  fullTitle: true,
+  canonicalPath,
+  openGraph: {
+    title,
+    description,
+    type: "service",
+    url: canonicalUrl,
+  },
+  twitter: {
+    title,
+    description,
+  },
+  breadcrumbs: [
+    { name: "Home", path: "/" },
+    { name: "Services", path: "/services" },
+    { name: "Damp Surveys", path: canonicalPath },
+  ],
+};
+
+const serviceSchema = {
+  "@context": "https://schema.org",
+  "@type": "Service",
+  name: "Professional Damp & Mould Surveys",
+  provider: { "@type": "Organization", name: "LEM Building Surveying Ltd" },
+  areaServed: ["Chester", "Wrexham", "Flintshire", "Connah’s Quay"],
+  serviceType: "Building Survey - Damp & Mould",
+  hasOfferCatalog: {
+    "@type": "OfferCatalog",
+    name: "Damp & Mould Investigation",
+    itemListElement: [
+      {
+        "@type": "Offer",
+        itemOffered: {
+          "@type": "Service",
+          name: "Evidence-led Damp/Mould Investigation & Report (BRE 245 where justified)",
+        },
+      },
+    ],
+  },
+};
+---
+
+<BaseLayout seo={seo}>
+  <article itemscope itemtype="https://schema.org/Service">
+    <header>
+      <h1 itemprop="name">Professional Damp &amp; Mould Surveys</h1>
+      <p>
+        <strong>Service areas:</strong> Chester, Wrexham, Flintshire, Connah’s Quay
+        and nearby towns.
+      </p>
+    </header>
+
+    <section itemprop="serviceType">
+      <h2>Why book a damp survey?</h2>
+      <p>
+        Whether you’re buying a home or dealing with persistent mould, an
+        evidence-led survey gets to the root cause — not just the symptoms.
+      </p>
+      <ul>
+        <li>
+          <strong>Condensation</strong> — ventilation, insulation and thermal-bridge
+          related issues
+        </li>
+        <li>
+          <strong>Penetrating damp</strong> — envelope defects and cavity insulation
+          bridging
+        </li>
+        <li>
+          <strong>Low-level moisture</strong> — we treat “rising damp” claims with
+          caution; we investigate bridging/alterations first and confirm capillary
+          rise via BRE 245 only where justified
+        </li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>What’s included</h2>
+      <ul>
+        <li>Moisture pattern mapping &amp; meter screening</li>
+        <li>Thermal imaging (where justified)</li>
+        <li>
+          Hygrothermal checks; ventilation assessment &amp; commissioning advice
+        </li>
+        <li>
+          Clear, prioritised action plan (defect repairs before treatments)
+        </li>
+        <li>Optional follow-up with the surveyor</li>
+      </ul>
+      <p>
+        We tailor our approach by building age and type — from Victorian
+        terraces in Chester to 1950s semis in Wrexham.
+      </p>
+    </section>
+
+    <section>
+      <h2>What happens next?</h2>
+      <ol>
+        <li>Request a free quote</li>
+        <li>We arrange a convenient inspection date</li>
+        <li>You receive your report within 48–72 hours</li>
+      </ol>
+      <p>
+        Learn more about causes &amp; fixes: <a
+          href="/blog/damp-mould-practical-guide"
+          >Damp &amp; Mould: The Practical Guide →</a
+        >
+      </p>
+    </section>
+
+    <section>
+      <a href="/contact" class="btn-primary">Request a Damp Survey Quote</a>
+    </section>
+
+    <script
+      type="application/ld+json"
+      is:inline
+      set:html={JSON.stringify(serviceSchema)}
+    />
+  </article>
+</BaseLayout>


### PR DESCRIPTION
## Summary
- add a dedicated /services/damp-surveys article with service schema and CTA
- add internal links from damp-focused articles to the new service page
- add prettier + astro plugin dev dependencies and format updated content

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68ceec117c148323bb2cc42b2dbb27f4