### PR TITLE
Add damp and mould blog posts to index

### DIFF
--- a/src/pages/blog-index.astro
+++ b/src/pages/blog-index.astro
@@ -88,6 +88,14 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <h2><a href="/damp-and-mould-action-plan-checklist">Damp &amp; Mould Action Plan Checklist</a></h2>
           <p>Structure evidence, monitoring and resident communication for compliant damp &amp; mould management.</p>
         </div>
+        <div class="service-card">
+          <h2><a href="/blog/damp-and-mould">Damp and Mould in Homes: What Buyers Need to Know</a></h2>
+          <p>A guide by LEM Building Surveying on identifying and resolving damp and mould issues in properties across North Wales and Cheshire.</p>
+        </div>
+        <div class="service-card">
+          <h2><a href="/blog/damp-mould-practical-guide">Damp and Mould: The Practical Guide (UK)</a></h2>
+          <p>Understand the real causes of damp and mould, how to diagnose them effectively, legal responsibilities, and what fixes actually work.</p>
+        </div>
       </div>
     </div>
   </section><div class="sticky-cta">


### PR DESCRIPTION
## Summary
- add a blog index card for the damp and mould guide with its published description
- add a blog index card for the practical damp and mould guide using its description text

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68cf1fd905988323aa7bb298e2692acc