### PR TITLE
Ensure base stylesheet loads without JavaScript

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -51,9 +51,7 @@ const localBusinessSchema = JSON.stringify(
       href="/assets/styles.min.css"
       onload="this.onload=null;this.rel='stylesheet'"
     />
-    <noscript>
-      <link rel="stylesheet" href="/assets/styles.min.css" />
-    </noscript>
+    <link rel="stylesheet" href="/assets/styles.min.css" />
     <style is:inline set:html={inlineTableStyles}></style>
     <link rel="icon" type="image/png" href="/logo-sticker.png" />
     <script src="https://web.cmp.usercentrics.eu/modules/autoblocker.js"></script>


### PR DESCRIPTION
## Summary
- add an always-on stylesheet link for styles.min.css while keeping the preload hint
- remove the noscript wrapper so the fallback CSS loads even when JavaScript is disabled

## Testing
- npm run build *(fails: ERR_MODULE_NOT_FOUND cssnano dependency missing in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cfbab6cd148331a69ed8b762a0b998