### PR TITLE
Remove legacy keywords meta tags

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -8,7 +8,6 @@ import { areaSelectorOptions } from '../data/areas';
     <title>About LEM Building Surveying Ltd | LEM Building Surveying</title>
 
         <meta content="Meet Liam Butler BSc AssocRICS MRPSA—independent surveyor serving Deeside, Chester &amp; beyond. Trusted advice, local knowledge, and clear reporting." name="description">
-        <meta content="Liam Butler surveyor, AssocRICS, MRPSA, building surveyor Chester, independent property surveyor, home surveys Deeside" name="keywords">
         <link href="https://www.lembuildingsurveying.co.uk/about" rel="canonical">
         <meta content="About LEM Building Surveying Ltd | LEM Building Surveying" property="og:title">
         <meta content="Meet Liam Butler BSc AssocRICS MRPSA—independent surveyor serving Deeside, Chester &amp; beyond. Trusted advice, local knowledge, and clear reporting." property="og:description">

--- a/src/pages/enquiry.astro
+++ b/src/pages/enquiry.astro
@@ -6,7 +6,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <Fragment slot="head">
     <title>Request a Property Survey | LEM Building Surveying</title>
         <meta content="Submit your property details to request a free, no-obligation quote for a building survey, damp report, EPC, or floorplan. Serving Deeside, Chester &amp; the North West." name="description">
-        <meta content="Request Building Survey Quote, Property Survey Form, RICS Survey Enquiry, Damp Survey Quote, Floorplan Survey Deeside Chester North West" name="keywords">
         <link rel="canonical" href="https://www.lembuildingsurveying.co.uk/enquiry">
         <meta property="og:title" content="Request a Property Survey | LEM Building Surveying">
         <meta property="og:description" content="Submit your property details to request a free, no-obligation quote for a building survey, damp report, EPC, or floorplan. Serving Deeside, Chester &amp; the North West.">

--- a/src/pages/faqs.astro
+++ b/src/pages/faqs.astro
@@ -9,10 +9,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       name="description"
       content="Get clear answers to common home survey questions and buyer advice. Learn when to book, what reports include, and how to choose the right RICS survey."
     />
-    <meta
-      name="keywords"
-      content="Survey FAQs, RICS Home Survey Questions, Buyer Advice, Home Survey Advice"
-    />
     <link rel="canonical" href="https://www.lembuildingsurveying.co.uk/faqs" />
     <meta
       property="og:title"

--- a/src/pages/independent-damp-survey-vs-contractor.astro
+++ b/src/pages/independent-damp-survey-vs-contractor.astro
@@ -9,10 +9,6 @@ import BaseLayout from "../layouts/BaseLayout.astro";
       content="Learn when to commission an independent damp surveyor instead of a contractor. Compare inspection methods, report quality, costs and the impartial advice you receive."
       name="description"
     />
-    <meta
-      content="independent damp survey, contractor damp report, damp survey vs damp proof company, impartial moisture assessment"
-      name="keywords"
-    />
     <link
       href="https://www.lembuildingsurveying.co.uk/independent-damp-survey-vs-contractor"
       rel="canonical"

--- a/src/pages/understanding-your-survey-report.astro
+++ b/src/pages/understanding-your-survey-report.astro
@@ -6,7 +6,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <Fragment slot="head">
     <title>Understanding Your Survey Report: A | LEM Building Surveying</title>
     <meta content="Learn how to read and interpret your home survey report with confidence. LEM Building Surveying Ltd explains red, amber and green ratings, key insights, and next steps." name="description">
-    <meta content="Understanding Home Survey, RICS Survey Explanation, HomeBuyer Report Help, Building Survey Guide, Property Report Advice" name="keywords">
     <link href="https://www.lembuildingsurveying.co.uk/understanding-your-survey-report" rel="canonical">
     <meta content="Understanding Your Survey Report: A | LEM Building Surveying" property="og:title">
     <meta content="Learn how to read and interpret your home survey report with confidence. LEM Building Surveying Ltd explains red, amber and green ratings, key insights, and next steps." property="og:description">

--- a/src/pages/what-a-rics-survey-can-reveal.astro
+++ b/src/pages/what-a-rics-survey-can-reveal.astro
@@ -6,7 +6,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <Fragment slot="head">
     <title>What a RICS Survey Can Reveal | LEM Building Surveying</title>
     <meta content="Discover what a RICS Home Survey can uncover before you commit to buying a property. Protect your investment with insights from LEM Building Surveying Ltd." name="description">
-    <meta content="RICS Home Survey, property defects, structural issues, damp survey, homebuyer advice, Chester surveyor, Wrexham property survey, Flintshire survey" name="keywords">
     <link href="https://www.lembuildingsurveying.co.uk/what-a-rics-survey-can-reveal" rel="canonical">
     <meta content="What a RICS Survey Can Reveal | LEM Building Surveying" property="og:title">
     <meta content="Discover what a RICS Home Survey can uncover before you commit to buying a property. Protect your investment with insights from LEM Building Surveying Ltd." property="og:description">


### PR DESCRIPTION
## Summary
- remove the deprecated `meta name="keywords"` tags from key marketing pages so they use modern metadata only
- verify there are no remaining keyword meta tags under `src/pages`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cfc3345f9083319025b2281e92cc6a