### PR TITLE
Add address details to about page organization schema

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -37,6 +37,14 @@ import { areaSelectorOptions } from '../data/areas';
               "Cheshire",
               "North West England"
             ],
+            "address": {
+              "@type": "PostalAddress",
+              "streetAddress": "Marlowe Avenue",
+              "addressLocality": "Connah's Quay",
+              "addressRegion": "Deeside, Flintshire",
+              "postalCode": "CH5 4HS",
+              "addressCountry": "GB"
+            },
             "member": {
               "@type": "Person",
               "name": "Liam Butler",


### PR DESCRIPTION
## Summary
- add the company postal address to the Organization JSON-LD on the about page so it matches the LocalBusiness schema configuration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68cfc3359a188331a3f6204d547223f2