### PR TITLE
Add Netlify postcode utilities and estimate email function

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,6 @@
 [build]
   command = "astro build"
   publish = "dist"
+
+[functions]
+  directory = "netlify/functions"

--- a/netlify/functions/postcode-autocomplete.js
+++ b/netlify/functions/postcode-autocomplete.js
@@ -1,0 +1,87 @@
+const BASE_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Access-Control-Allow-Methods': 'GET,OPTIONS',
+  'Access-Control-Max-Age': '86400',
+};
+
+const JSON_HEADERS = {
+  ...BASE_HEADERS,
+  'Content-Type': 'application/json',
+};
+
+const jsonResponse = (statusCode, payload) => ({
+  statusCode,
+  headers: JSON_HEADERS,
+  body: JSON.stringify(payload),
+});
+
+exports.handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 204,
+      headers: BASE_HEADERS,
+    };
+  }
+
+  if (event.httpMethod !== 'GET') {
+    return jsonResponse(405, { error: 'Method Not Allowed' });
+  }
+
+  const params = new URLSearchParams();
+  const incomingParams = event.queryStringParameters || {};
+
+  for (const [key, value] of Object.entries(incomingParams)) {
+    if (value !== undefined && value !== null && String(value).length > 0) {
+      params.set(key, String(value));
+    }
+  }
+
+  const trimmedQuery = params.get('q')?.trim();
+
+  if (!trimmedQuery) {
+    return jsonResponse(400, { error: 'Query parameter "q" is required' });
+  }
+
+  params.set('q', trimmedQuery);
+
+  const endpoint = new URL('https://api.postcodes.io/postcodes');
+  endpoint.search = params.toString();
+
+  try {
+    const res = await fetch(endpoint, {
+      headers: {
+        Accept: 'application/json',
+      },
+    });
+
+    const text = await res.text();
+    const data = text ? JSON.parse(text) : {};
+
+    if (!res.ok) {
+      return jsonResponse(res.status || 502, {
+        status: data?.status ?? res.status,
+        query: trimmedQuery,
+        error: data?.error || 'Postcode autocomplete lookup failed',
+      });
+    }
+
+    const result = Array.isArray(data?.result) ? data.result : [];
+    const suggestions = result
+      .map((entry) => entry?.postcode || entry)
+      .filter(Boolean);
+
+    return jsonResponse(res.status || 200, {
+      status: data?.status ?? res.status,
+      query: trimmedQuery,
+      limit: params.get('limit') ? Number(params.get('limit')) : undefined,
+      result,
+      suggestions,
+    });
+  } catch (error) {
+    return jsonResponse(502, {
+      error: 'Failed to reach postcode autocomplete service',
+      details: error?.message,
+    });
+  }
+};

--- a/netlify/functions/postcode-distance.js
+++ b/netlify/functions/postcode-distance.js
@@ -1,0 +1,202 @@
+const BASE_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Access-Control-Allow-Methods': 'GET,OPTIONS',
+  'Access-Control-Max-Age': '86400',
+};
+
+const JSON_HEADERS = {
+  ...BASE_HEADERS,
+  'Content-Type': 'application/json',
+};
+
+const HOME_BASE = {
+  latitude: 53.210058,
+  longitude: -3.053622,
+  postcode: 'CH5 4HS',
+};
+
+const DISTANCE_BANDS = [
+  { id: 'within-10-miles', label: '0-10 miles', maxMiles: 10 },
+  { id: 'within-20-miles', label: '10-20 miles', maxMiles: 20 },
+  { id: 'within-35-miles', label: '20-35 miles', maxMiles: 35 },
+  { id: 'within-50-miles', label: '35-50 miles', maxMiles: 50 },
+  { id: 'over-50-miles', label: '50+ miles', maxMiles: Infinity },
+];
+
+const EARTH_RADIUS_MILES = 3958.7613;
+
+const responseWithCors = (statusCode, body) => ({
+  statusCode,
+  headers: JSON_HEADERS,
+  body: JSON.stringify(body),
+});
+
+const sanitisePostcode = (value) => value.trim().toUpperCase();
+
+const toRadians = (value) => (value * Math.PI) / 180;
+
+const haversineDistanceMiles = (from, to) => {
+  const latDelta = toRadians(to.latitude - from.latitude);
+  const lonDelta = toRadians(to.longitude - from.longitude);
+
+  const fromLat = toRadians(from.latitude);
+  const toLat = toRadians(to.latitude);
+
+  const a =
+    Math.sin(latDelta / 2) ** 2 +
+    Math.cos(fromLat) * Math.cos(toLat) * Math.sin(lonDelta / 2) ** 2;
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+  return EARTH_RADIUS_MILES * c;
+};
+
+const determineBand = (distanceMiles) => {
+  let previousMax = 0;
+
+  for (const band of DISTANCE_BANDS) {
+    if (distanceMiles <= band.maxMiles) {
+      return {
+        id: band.id,
+        label: band.label,
+        minMiles: Number(previousMax.toFixed(2)),
+        maxMiles:
+          band.maxMiles === Infinity ? null : Number(band.maxMiles.toFixed(2)),
+      };
+    }
+
+    previousMax = band.maxMiles;
+  }
+
+  return {
+    id: 'over-50-miles',
+    label: '50+ miles',
+    minMiles: Number(previousMax.toFixed(2)),
+    maxMiles: null,
+  };
+};
+
+const fetchJson = async (url) => {
+  const res = await fetch(url);
+  const text = await res.text();
+  let data;
+
+  try {
+    data = text ? JSON.parse(text) : {};
+  } catch (error) {
+    const parseError = new Error('Invalid response from postcode service');
+    parseError.cause = error;
+    parseError.statusCode = 502;
+    throw parseError;
+  }
+
+  return { res, data };
+};
+
+const geocodeLocation = async (input) => {
+  const normalised = sanitisePostcode(input);
+
+  if (!normalised) {
+    const error = new Error('Postcode or outcode is required');
+    error.statusCode = 400;
+    throw error;
+  }
+
+  const postcodeQuery = normalised.replace(/\s+/g, '');
+  const outcodeQuery = normalised.split(' ')[0];
+
+  try {
+    const { res, data } = await fetchJson(
+      `https://api.postcodes.io/postcodes/${encodeURIComponent(postcodeQuery)}`,
+    );
+
+    if (res.ok && data?.result) {
+      const { latitude, longitude } = data.result;
+      return {
+        latitude,
+        longitude,
+        locationType: 'postcode',
+        query: postcodeQuery,
+        raw: data.result,
+      };
+    }
+
+    if (res.status !== 404) {
+      const error = new Error(data?.error || 'Unable to geocode postcode');
+      error.statusCode = res.status || 502;
+      throw error;
+    }
+  } catch (error) {
+    if (error?.statusCode && error.statusCode !== 404) {
+      throw error;
+    }
+  }
+
+  const { res, data } = await fetchJson(
+    `https://api.postcodes.io/outcodes/${encodeURIComponent(outcodeQuery)}`,
+  );
+
+  if (res.ok && data?.result) {
+    const { latitude, longitude } = data.result;
+    return {
+      latitude,
+      longitude,
+      locationType: 'outcode',
+      query: outcodeQuery,
+      raw: data.result,
+    };
+  }
+
+  const error = new Error(data?.error || 'Unable to geocode location');
+  error.statusCode = res.status || 502;
+  throw error;
+};
+
+exports.handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 204,
+      headers: BASE_HEADERS,
+    };
+  }
+
+  if (event.httpMethod !== 'GET') {
+    return responseWithCors(405, { error: 'Method Not Allowed' });
+  }
+
+  const postcode = event.queryStringParameters?.postcode;
+
+  if (!postcode) {
+    return responseWithCors(400, { error: 'Query parameter "postcode" is required' });
+  }
+
+  try {
+    const target = await geocodeLocation(postcode);
+    const distanceMiles = Number(
+      haversineDistanceMiles(HOME_BASE, target).toFixed(2),
+    );
+    const distanceKilometres = Number((distanceMiles * 1.60934).toFixed(2));
+
+    const band = determineBand(distanceMiles);
+
+    return responseWithCors(200, {
+      query: postcode,
+      reference: HOME_BASE.postcode,
+      locationType: target.locationType,
+      coordinates: {
+        latitude: target.latitude,
+        longitude: target.longitude,
+      },
+      distance: {
+        miles: distanceMiles,
+        kilometres: distanceKilometres,
+      },
+      band,
+    });
+  } catch (error) {
+    const statusCode = error?.statusCode || 502;
+    return responseWithCors(statusCode, {
+      error: error?.message || 'Unexpected error determining distance',
+    });
+  }
+};

--- a/netlify/functions/send-estimate-email.mjs
+++ b/netlify/functions/send-estimate-email.mjs
@@ -1,0 +1,807 @@
+import { PDFDocument, StandardFonts } from 'pdf-lib';
+import { Resend } from 'resend';
+
+const BASE_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Access-Control-Allow-Methods': 'POST,OPTIONS',
+  'Access-Control-Max-Age': '86400',
+};
+
+const JSON_HEADERS = {
+  ...BASE_HEADERS,
+  'Content-Type': 'application/json',
+};
+
+const jsonResponse = (statusCode, payload) => ({
+  statusCode,
+  headers: JSON_HEADERS,
+  body: JSON.stringify(payload),
+});
+
+const slugify = (value, fallback) => {
+  if (!value || typeof value !== 'string') {
+    return fallback;
+  }
+
+  const slug = value
+    .normalize('NFD')
+    .replace(/[^\w\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-');
+
+  return slug || fallback;
+};
+
+const parseAmount = (value) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  const cleaned = String(value).replace(/[^0-9.-]+/g, '');
+  if (!cleaned) {
+    return null;
+  }
+
+  const parsed = Number(cleaned);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const parseDate = (value) => {
+  if (!value) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+const formatDate = (value) => {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    return new Intl.DateTimeFormat('en-GB', { dateStyle: 'long' }).format(value);
+  } catch (error) {
+    return null;
+  }
+};
+
+const normaliseLineItems = (items) => {
+  if (!Array.isArray(items)) {
+    return [];
+  }
+
+  return items
+    .map((item) => {
+      if (item === null || item === undefined) {
+        return null;
+      }
+
+      if (typeof item === 'string') {
+        return { description: item, amount: null };
+      }
+
+      if (typeof item === 'number') {
+        return { description: '', amount: item };
+      }
+
+      const description =
+        item.description ?? item.label ?? item.title ?? item.name ?? '';
+
+      const baseAmount =
+        parseAmount(item.amount ?? item.price ?? item.total ?? item.value);
+
+      const quantity =
+        item.quantity !== undefined ? Number(item.quantity) : undefined;
+      const unitPrice = parseAmount(item.unitPrice ?? item.unit_price);
+
+      let amount = baseAmount;
+
+      if (amount === null && unitPrice !== null) {
+        const qty = Number.isFinite(quantity) ? quantity : 1;
+        amount = unitPrice * qty;
+      }
+
+      const notes = item.notes ?? item.summary ?? undefined;
+
+      return description || amount !== null
+        ? {
+            description: description ? String(description) : '',
+            amount,
+            notes: notes ? String(notes) : undefined,
+            quantity: Number.isFinite(quantity) ? quantity : undefined,
+          }
+        : null;
+    })
+    .filter(Boolean);
+};
+
+const sumLineItems = (items) =>
+  items.reduce(
+    (total, item) => total + (typeof item.amount === 'number' ? item.amount : 0),
+    0,
+  );
+
+const wrapText = (text, font, size, maxWidth) => {
+  const content = String(text ?? '').trim();
+
+  if (!content) {
+    return [];
+  }
+
+  const paragraphs = content.split(/\r?\n+/);
+  const lines = [];
+
+  for (const paragraph of paragraphs) {
+    const words = paragraph.split(/\s+/).filter(Boolean);
+
+    if (words.length === 0) {
+      lines.push('');
+      continue;
+    }
+
+    let currentLine = words.shift();
+
+    for (const word of words) {
+      const testLine = `${currentLine} ${word}`;
+      if (font.widthOfTextAtSize(testLine, size) <= maxWidth) {
+        currentLine = testLine;
+        continue;
+      }
+
+      lines.push(currentLine);
+      currentLine = word;
+    }
+
+    if (currentLine) {
+      lines.push(currentLine);
+    }
+
+    lines.push('');
+  }
+
+  if (lines.length && lines[lines.length - 1] === '') {
+    lines.pop();
+  }
+
+  return lines;
+};
+
+const computeValidUntil = (issueDate, explicitValidUntil, validForDays) => {
+  const providedDate = parseDate(explicitValidUntil);
+  if (providedDate) {
+    return providedDate;
+  }
+
+  if (!issueDate || validForDays === null || validForDays === undefined) {
+    return null;
+  }
+
+  const days = Number(validForDays);
+  if (!Number.isFinite(days)) {
+    return null;
+  }
+
+  const computed = new Date(issueDate);
+  computed.setDate(computed.getDate() + days);
+  return computed;
+};
+
+const mergeEstimateData = (payload) => {
+  const base = { ...(payload.estimate ?? {}) };
+
+  const fieldAliases = {
+    clientName: ['clientName', 'name', 'customerName'],
+    clientEmail: ['clientEmail', 'email'],
+    propertyAddress: ['propertyAddress', 'address'],
+    surveyType: ['surveyType'],
+    lineItems: ['lineItems', 'items', 'fees'],
+    extras: ['extras', 'optionalExtras', 'optionalItems'],
+    adjustments: ['adjustments', 'discounts'],
+    notes: ['notes'],
+    turnaround: ['turnaround', 'leadTime'],
+    total: ['total', 'grandTotal'],
+    currency: ['currency'],
+    issueDate: ['issueDate', 'issuedAt'],
+    validUntil: ['validUntil', 'expiresOn'],
+    validForDays: ['validForDays', 'validityDays'],
+    reference: ['reference', 'estimateNumber', 'estimateId'],
+    tax: ['tax', 'vat', 'vatAmount'],
+    summary: ['summary', 'description'],
+  };
+
+  for (const [key, aliases] of Object.entries(fieldAliases)) {
+    if (base[key] !== undefined) {
+      continue;
+    }
+
+    for (const alias of aliases) {
+      if (payload[alias] !== undefined) {
+        base[key] = payload[alias];
+        break;
+      }
+    }
+  }
+
+  return base;
+};
+
+const prepareEstimate = (payload) => {
+  const rawEstimate = mergeEstimateData(payload);
+
+  const currency = (rawEstimate.currency || 'GBP').toUpperCase();
+  let currencyFormatter;
+
+  try {
+    currencyFormatter = new Intl.NumberFormat('en-GB', {
+      style: 'currency',
+      currency,
+    });
+  } catch (error) {
+    currencyFormatter = new Intl.NumberFormat('en-GB', {
+      style: 'currency',
+      currency: 'GBP',
+    });
+  }
+
+  const lineItems = normaliseLineItems(rawEstimate.lineItems);
+  const extras = normaliseLineItems(
+    rawEstimate.extras ?? rawEstimate.optionalExtras ?? rawEstimate.optionalItems,
+  );
+  const adjustments = normaliseLineItems(rawEstimate.adjustments);
+
+  const subtotal = sumLineItems(lineItems);
+  const adjustmentsTotal = sumLineItems(adjustments);
+  const tax = parseAmount(rawEstimate.tax);
+
+  let total = parseAmount(rawEstimate.total);
+  if (total === null) {
+    total = subtotal + adjustmentsTotal + (tax ?? 0);
+  }
+
+  const issueDate = parseDate(
+    rawEstimate.issueDate ?? rawEstimate.issuedAt ?? rawEstimate.createdAt ?? new Date(),
+  );
+  const validForDays =
+    rawEstimate.validForDays ?? rawEstimate.validityDays ?? rawEstimate.valid_for_days;
+  const validUntil = computeValidUntil(issueDate, rawEstimate.validUntil, validForDays);
+
+  return {
+    raw: rawEstimate,
+    currency,
+    currencyFormatter,
+    lineItems,
+    extras,
+    adjustments,
+    subtotal,
+    adjustmentsTotal,
+    tax,
+    total,
+    issueDate,
+    validForDays:
+      validForDays !== undefined && validForDays !== null
+        ? Number(validForDays)
+        : undefined,
+    validUntil,
+    formatted: {
+      issueDate: formatDate(issueDate),
+      validUntil: formatDate(validUntil),
+      subtotal: currencyFormatter.format(subtotal),
+      adjustmentsTotal:
+        adjustmentsTotal !== 0 ? currencyFormatter.format(adjustmentsTotal) : null,
+      tax: tax !== null ? currencyFormatter.format(tax) : null,
+      total: total !== null ? currencyFormatter.format(total) : null,
+    },
+  };
+};
+
+const createEmailText = (estimate, prepared, company) => {
+  const name =
+    estimate.clientName || estimate.customerName || estimate.name || 'there';
+  const surveyType = estimate.surveyType || 'survey';
+  const lines = [
+    `Hello ${name},`,
+    '',
+    `Please find attached your ${surveyType.toLowerCase()} estimate.`,
+  ];
+
+  if (prepared.total !== null && prepared.formatted.total) {
+    lines.push('', `Total: ${prepared.formatted.total}`);
+  }
+
+  if (estimate.turnaround) {
+    lines.push('', `Turnaround: ${estimate.turnaround}.`);
+  }
+
+  if (prepared.validForDays) {
+    const validity = prepared.validForDays;
+    const validityText = prepared.formatted.validUntil
+      ? `${validity} days (until ${prepared.formatted.validUntil})`
+      : `${validity} days`;
+    lines.push('', `This estimate is valid for ${validityText}.`);
+  } else if (prepared.formatted.validUntil) {
+    lines.push('', `This estimate is valid until ${prepared.formatted.validUntil}.`);
+  }
+
+  lines.push(
+    '',
+    'Let me know if you have any questions or if you would like to proceed.',
+    '',
+    'Kind regards,',
+    company.name || 'LEM Building Surveying',
+  );
+
+  if (company.phone) {
+    lines.push(company.phone);
+  }
+
+  if (company.email) {
+    lines.push(company.email);
+  }
+
+  return lines.join('\n');
+};
+
+const buildEmailHtml = (text) =>
+  text
+    .split(/\n{2,}/)
+    .map((paragraph) =>
+      `<p>${paragraph
+        .split(/\n/)
+        .map((line) => line.replace(/[&<>]/g, (char) => {
+          if (char === '&') return '&amp;';
+          if (char === '<') return '&lt;';
+          if (char === '>') return '&gt;';
+          return char;
+        }))
+        .join('<br />')}</p>`,
+    )
+    .join('');
+
+const generateEstimatePdf = async (estimate, prepared, company, options = {}) => {
+  const pdfDoc = await PDFDocument.create();
+  let page = pdfDoc.addPage();
+  const { width, height } = page.getSize();
+  const margin = 50;
+  let cursorY = height - margin;
+  const maxWidth = width - margin * 2;
+
+  const regularFont = await pdfDoc.embedFont(StandardFonts.Helvetica);
+  const boldFont = await pdfDoc.embedFont(StandardFonts.HelveticaBold);
+
+  const ensureSpace = (requiredHeight) => {
+    if (cursorY - requiredHeight < margin) {
+      page = pdfDoc.addPage();
+      cursorY = page.getHeight() - margin;
+    }
+  };
+
+  const drawTextLine = (text, { font = regularFont, size = 12 } = {}) => {
+    if (!text) {
+      return;
+    }
+
+    const lineHeight = size + 4;
+    ensureSpace(lineHeight);
+    page.drawText(text, { x: margin, y: cursorY, font, size });
+    cursorY -= lineHeight;
+  };
+
+  const drawParagraph = (
+    text,
+    { font = regularFont, size = 12, bullet = false } = {},
+  ) => {
+    const lineHeight = size + 4;
+    const lines = wrapText(text, font, size, maxWidth - (bullet ? 14 : 0));
+
+    for (const line of lines) {
+      ensureSpace(lineHeight);
+      if (bullet && line) {
+        page.drawText('•', { x: margin, y: cursorY, font, size });
+        page.drawText(line, {
+          x: margin + 14,
+          y: cursorY,
+          font,
+          size,
+        });
+      } else if (line) {
+        page.drawText(line, { x: margin, y: cursorY, font, size });
+      }
+      cursorY -= lineHeight;
+    }
+  };
+
+  const drawLineItem = (item) => {
+    if (!item.description && item.amount === null) {
+      return;
+    }
+
+    const amountText =
+      typeof item.amount === 'number'
+        ? prepared.currencyFormatter.format(item.amount)
+        : item.amountText;
+
+    const lines = wrapText(item.description || '', regularFont, 12, maxWidth - 110);
+
+    if (lines.length === 0) {
+      lines.push('');
+    }
+
+    const lineHeight = 16;
+
+    for (const [index, line] of lines.entries()) {
+      ensureSpace(lineHeight);
+      page.drawText(line, { x: margin, y: cursorY, font: regularFont, size: 12 });
+
+      if (index === 0 && amountText) {
+        const amountWidth = boldFont.widthOfTextAtSize(amountText, 12);
+        page.drawText(amountText, {
+          x: margin + maxWidth - amountWidth,
+          y: cursorY,
+          font: boldFont,
+          size: 12,
+        });
+      }
+
+      cursorY -= lineHeight;
+    }
+
+    if (item.notes) {
+      drawParagraph(item.notes, { font: regularFont, size: 10 });
+    }
+  };
+
+  const drawSectionTitle = (title) => {
+    cursorY -= 6;
+    drawTextLine(title, { font: boldFont, size: 14 });
+  };
+
+  const drawTotalRow = (label, value, { bold = false } = {}) => {
+    const font = bold ? boldFont : regularFont;
+    const lineHeight = 18;
+    ensureSpace(lineHeight);
+    page.drawText(label, { x: margin, y: cursorY, font, size: 12 });
+
+    if (value) {
+      const text = typeof value === 'number'
+        ? prepared.currencyFormatter.format(value)
+        : value;
+      const textWidth = font.widthOfTextAtSize(text, 12);
+      page.drawText(text, {
+        x: margin + maxWidth - textWidth,
+        y: cursorY,
+        font,
+        size: 12,
+      });
+    }
+
+    cursorY -= lineHeight;
+  };
+
+  const headerLines = [];
+  if (company.name) {
+    headerLines.push(company.name);
+  }
+  if (company.tagline) {
+    headerLines.push(company.tagline);
+  }
+  if (company.website || company.email || company.phone) {
+    headerLines.push(
+      [company.website, company.email, company.phone].filter(Boolean).join(' • '),
+    );
+  }
+  if (company.address) {
+    headerLines.push(company.address);
+  }
+
+  headerLines.forEach((line) => drawTextLine(line, { font: regularFont, size: 10 }));
+
+  if (headerLines.length) {
+    cursorY -= 6;
+  }
+
+  drawTextLine('Survey Estimate', { font: boldFont, size: 20 });
+
+  if (estimate.reference) {
+    drawTextLine(`Reference: ${estimate.reference}`, { font: regularFont, size: 12 });
+  }
+
+  if (prepared.formatted.issueDate) {
+    drawTextLine(`Issued: ${prepared.formatted.issueDate}`, {
+      font: regularFont,
+      size: 12,
+    });
+  }
+
+  if (prepared.formatted.validUntil) {
+    drawTextLine(`Valid until: ${prepared.formatted.validUntil}`, {
+      font: regularFont,
+      size: 12,
+    });
+  }
+
+  cursorY -= 10;
+
+  if (estimate.clientName || estimate.clientEmail) {
+    drawSectionTitle('Client');
+    if (estimate.clientName) {
+      drawTextLine(estimate.clientName, { font: regularFont, size: 12 });
+    }
+    if (estimate.clientEmail) {
+      drawTextLine(estimate.clientEmail, { font: regularFont, size: 12 });
+    }
+    cursorY -= 6;
+  }
+
+  if (estimate.propertyAddress) {
+    drawSectionTitle('Property');
+    drawParagraph(estimate.propertyAddress, { font: regularFont, size: 12 });
+    cursorY -= 6;
+  }
+
+  const details = [];
+  if (estimate.surveyType) {
+    details.push(`Survey type: ${estimate.surveyType}`);
+  }
+  if (estimate.turnaround) {
+    details.push(`Turnaround: ${estimate.turnaround}`);
+  }
+  if (estimate.summary) {
+    details.push(estimate.summary);
+  }
+
+  if (details.length) {
+    drawSectionTitle('Details');
+    details.forEach((line) => drawParagraph(line, { font: regularFont, size: 12 }));
+    cursorY -= 6;
+  }
+
+  if (prepared.lineItems.length) {
+    drawSectionTitle('Fees');
+    prepared.lineItems.forEach((item) => drawLineItem(item));
+  }
+
+  if (prepared.adjustments.length) {
+    cursorY -= 6;
+    drawSectionTitle('Adjustments');
+    prepared.adjustments.forEach((item) => drawLineItem(item));
+  }
+
+  if (prepared.extras.length) {
+    cursorY -= 6;
+    drawSectionTitle('Optional extras');
+    prepared.extras.forEach((item) => drawLineItem(item));
+  }
+
+  cursorY -= 6;
+  drawSectionTitle('Summary');
+  drawTotalRow('Subtotal', prepared.formatted.subtotal);
+
+  if (prepared.adjustments.length && prepared.formatted.adjustmentsTotal) {
+    drawTotalRow('Adjustments', prepared.formatted.adjustmentsTotal);
+  }
+
+  if (prepared.formatted.tax) {
+    drawTotalRow('Tax', prepared.formatted.tax);
+  }
+
+  if (prepared.formatted.total) {
+    drawTotalRow('Total', prepared.formatted.total, { bold: true });
+  }
+
+  if (estimate.notes) {
+    cursorY -= 6;
+    drawSectionTitle('Notes');
+    drawParagraph(estimate.notes, { font: regularFont, size: 11 });
+  }
+
+  if (company && (company.email || company.phone || company.website)) {
+    cursorY -= 12;
+    drawSectionTitle('Contact');
+    if (company.email) {
+      drawTextLine(company.email, { font: regularFont, size: 10 });
+    }
+    if (company.phone) {
+      drawTextLine(company.phone, { font: regularFont, size: 10 });
+    }
+    if (company.website) {
+      drawTextLine(company.website, { font: regularFont, size: 10 });
+    }
+  }
+
+  const pdfBytes = await pdfDoc.save();
+  const filename = options.filename
+    ? options.filename
+    : `survey-estimate-${slugify(
+        estimate.reference || estimate.clientName || Date.now().toString(),
+        'lem-survey',
+      ).toLowerCase()}.pdf`;
+
+  return {
+    filename,
+    bytes: pdfBytes,
+    base64: Buffer.from(pdfBytes).toString('base64'),
+  };
+};
+
+export async function handler(event) {
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 204,
+      headers: BASE_HEADERS,
+    };
+  }
+
+  if (event.httpMethod !== 'POST') {
+    return jsonResponse(405, { error: 'Method Not Allowed' });
+  }
+
+  if (!event.body) {
+    return jsonResponse(400, { error: 'Request body is required' });
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(event.body);
+  } catch (error) {
+    return jsonResponse(400, { error: 'Invalid JSON payload' });
+  }
+
+  const toRecipientsRaw =
+    payload.to ?? payload.recipient ?? payload.email ?? payload.clientEmail;
+  const toRecipients = Array.isArray(toRecipientsRaw)
+    ? toRecipientsRaw.filter(Boolean)
+    : [toRecipientsRaw].filter(Boolean);
+
+  if (!toRecipients.length) {
+    return jsonResponse(400, { error: 'A recipient "to" address is required' });
+  }
+
+  const prepared = prepareEstimate(payload);
+  const estimate = {
+    ...prepared.raw,
+    clientName:
+      prepared.raw.clientName ?? payload.clientName ?? payload.name ?? 'Client',
+    clientEmail: prepared.raw.clientEmail ?? payload.clientEmail ?? payload.email,
+  };
+
+  const defaultCompany = {
+    name: process.env.COMPANY_NAME || 'LEM Building Surveying',
+    email: process.env.COMPANY_EMAIL || null,
+    phone: process.env.COMPANY_PHONE || null,
+    website:
+      process.env.COMPANY_WEBSITE || 'https://www.lembuildingsurveying.co.uk',
+    address: process.env.COMPANY_ADDRESS || null,
+  };
+
+  const company = {
+    ...defaultCompany,
+    ...(estimate.company || {}),
+    ...(payload.company || {}),
+  };
+
+  if (!company.email) {
+    company.email = payload.replyTo || process.env.RESEND_FROM_EMAIL || null;
+  }
+
+  const pdf = await generateEstimatePdf(estimate, prepared, company, {
+    filename: payload.filename,
+  });
+
+  const includePdfInResponse = payload.includePdf !== false;
+
+  const subjectPrefix = company.name ? `${company.name} — ` : '';
+  const subject =
+    payload.subject ||
+    `${subjectPrefix}${
+      estimate.surveyType ? `${estimate.surveyType} ` : ''
+    }Estimate${estimate.reference ? ` (${estimate.reference})` : ''}`;
+
+  const emailText = payload.text || createEmailText(estimate, prepared, company);
+  const emailHtml = payload.html || buildEmailHtml(emailText);
+
+  const fromAddress =
+    payload.from || process.env.RESEND_FROM_EMAIL || company.email || null;
+
+  const cc = Array.isArray(payload.cc)
+    ? payload.cc
+    : payload.cc
+    ? [payload.cc]
+    : undefined;
+  const bcc = Array.isArray(payload.bcc)
+    ? payload.bcc
+    : payload.bcc
+    ? [payload.bcc]
+    : undefined;
+
+  const replyTo = payload.replyTo || company.email || undefined;
+
+  let emailResult;
+
+  if (process.env.RESEND_API_KEY) {
+    if (!fromAddress) {
+      return jsonResponse(400, {
+        error:
+          'RESEND_API_KEY is configured but no "from" address was provided. Set the request "from" field or RESEND_FROM_EMAIL.',
+      });
+    }
+
+    try {
+      const resend = new Resend(process.env.RESEND_API_KEY);
+      const sendPayload = {
+        from: fromAddress,
+        to: toRecipients,
+        subject,
+        text: emailText,
+        html: emailHtml,
+        attachments: [
+          {
+            filename: pdf.filename,
+            content: pdf.base64,
+          },
+        ],
+      };
+
+      if (cc?.length) {
+        sendPayload.cc = cc;
+      }
+
+      if (bcc?.length) {
+        sendPayload.bcc = bcc;
+      }
+
+      if (replyTo) {
+        sendPayload.reply_to = replyTo;
+      }
+
+      const result = await resend.emails.send(sendPayload);
+
+      if (result?.error) {
+        throw new Error(result.error.message || 'Resend API error');
+      }
+
+      emailResult = {
+        attempted: true,
+        id: result?.data?.id || result?.id || null,
+      };
+    } catch (error) {
+      return jsonResponse(502, {
+        error: 'Failed to send estimate email',
+        details: error?.message,
+        pdf: includePdfInResponse
+          ? { filename: pdf.filename, base64: pdf.base64 }
+          : { filename: pdf.filename },
+      });
+    }
+  } else {
+    emailResult = {
+      attempted: false,
+      skipped: true,
+      reason: 'RESEND_API_KEY is not configured. Email was not sent.',
+    };
+  }
+
+  return jsonResponse(200, {
+    message: 'Estimate generated',
+    pdf: includePdfInResponse
+      ? { filename: pdf.filename, base64: pdf.base64 }
+      : { filename: pdf.filename },
+    email: emailResult,
+    totals: {
+      currency: prepared.currency,
+      subtotal: prepared.subtotal,
+      tax: prepared.tax,
+      total: prepared.total,
+    },
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,10 @@
     "": {
       "name": "cozy-daffodil-f4598c",
       "version": "1.0.0",
+      "dependencies": {
+        "pdf-lib": "^1.17.1",
+        "resend": "^6.1.0"
+      },
       "devDependencies": {
         "@astrojs/check": "^0.9.4",
         "@types/node": "^20.14.10",
@@ -1654,6 +1658,24 @@
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
+      }
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -6622,6 +6644,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parse-latin": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
@@ -6721,6 +6749,24 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -7190,6 +7236,23 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/resend": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.1.0.tgz",
+      "integrity": "sha512-H0cJI2pcLk5/dGwyvZUHu+O7X/q6arvc40EWm+pRPuy+PSWojH5utZtmDBUZ2L0+gVwYZiWs6y2lw6GQA1z1rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@react-email/render": "^1.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
     },
     "node_modules/restore-cursor": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -20,5 +20,9 @@
     "terser": "^5.31.3",
     "typescript": "^5.5.4",
     "vitest": "^1.6.0"
+  },
+  "dependencies": {
+    "pdf-lib": "^1.17.1",
+    "resend": "^6.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- add postcode-distance Netlify function to geocode postcodes/outcodes, compute Haversine distance from CH5 4HS, and return a distance band with CORS headers
- add postcode-autocomplete Netlify function that proxies Postcodes.io autocomplete with the same CORS behaviour
- add send-estimate-email function that renders a PDF quote and optionally emails it via Resend, plus configure Netlify to deploy the functions and add required dependencies

## Testing
- npx vitest run --reporter=basic

------
https://chatgpt.com/codex/tasks/task_b_68cfd21352dc83239a57660d9572c02a