### PR TITLE
Add pricing engine and quote calculator

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,8 +1,10 @@
+import react from '@astrojs/react';
 import { defineConfig } from 'astro/config';
 
 export default defineConfig({
   site: 'https://www.lembuildingsurveying.co.uk',
   output: 'static',
+  integrations: [react()],
   build: {
     format: 'file'
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,16 @@
     "": {
       "name": "cozy-daffodil-f4598c",
       "version": "1.0.0",
+      "dependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
       "devDependencies": {
         "@astrojs/check": "^0.9.4",
+        "@astrojs/react": "^4.3.1",
         "@types/node": "^20.14.10",
+        "@types/react": "^18.3.3",
+        "@types/react-dom": "^18.3.0",
         "astro": "^4.13.1",
         "jsdom": "^24.0.0",
         "lightningcss": "^1.25.1",
@@ -153,6 +160,535 @@
       },
       "engines": {
         "node": "^18.17.1 || ^20.3.0 || >=21.0.0"
+      }
+    },
+    "node_modules/@astrojs/react": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/react/-/react-4.3.1.tgz",
+      "integrity": "sha512-Jhv35TsDHuQLvwof2z10P3g1s9wIR4UN9jE7O4NZBJNXOt/+qk+L0rY9th4SX7VzccKmRltUGxAhI1cXH52gXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitejs/plugin-react": "^4.7.0",
+        "ultrahtml": "^1.6.0",
+        "vite": "^6.3.6"
+      },
+      "engines": {
+        "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0",
+        "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
+        "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/esbuild": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/vite": {
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
+      "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -447,6 +983,38 @@
         "@babel/helper-plugin-utils": "^7.27.1",
         "@babel/plugin-syntax-jsx": "^7.27.1",
         "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -980,6 +1548,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -997,6 +1582,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -1012,6 +1614,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -1666,6 +2285,13 @@
         "node": ">=14"
       }
     },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
@@ -2189,6 +2815,34 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.24",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
+      "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -2202,6 +2856,27 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "1.6.1",
@@ -3267,6 +3942,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -3857,6 +4539,24 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/fill-range": {
@@ -4750,7 +5450,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -5247,6 +5946,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/loupe": {
@@ -6957,12 +7668,47 @@
       ],
       "license": "MIT"
     },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/readdirp": {
       "version": "4.1.2",
@@ -7374,6 +8120,15 @@
       },
       "engines": {
         "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/section-matter": {
@@ -7830,6 +8585,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
     "node_modules/tinypool": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
@@ -8001,6 +8773,13 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
       "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ultrahtml": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.6.0.tgz",
+      "integrity": "sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -10,9 +10,16 @@
     "check": "astro check",
     "test": "vitest run"
   },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
   "devDependencies": {
     "@astrojs/check": "^0.9.4",
+    "@astrojs/react": "^4.3.1",
     "@types/node": "^20.14.10",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
     "astro": "^4.13.1",
     "jsdom": "^24.0.0",
     "lightningcss": "^1.25.1",

--- a/src/components/AreaLinks.tsx
+++ b/src/components/AreaLinks.tsx
@@ -1,0 +1,60 @@
+import { useMemo } from 'react';
+
+import { AREA_LINKS, findAreaConfig, type AreaLink as AreaLinkConfig } from '../lib/areas';
+
+interface AreaLinksProps {
+  areas?: string[];
+  className?: string;
+}
+
+const normalise = (value: string) => value.trim().toLowerCase();
+
+const buildLinks = (areas?: string[]): AreaLinkConfig[] => {
+  if (!areas || areas.length === 0) {
+    return AREA_LINKS;
+  }
+
+  const seen = new Set<string>();
+  const resolved: AreaLinkConfig[] = [];
+
+  for (const area of areas) {
+    const config = findAreaConfig(area);
+    if (!config) continue;
+
+    const link = AREA_LINKS.find(
+      (entry) => entry.outcode === config.outcode && normalise(entry.label) === normalise(config.label),
+    );
+
+    if (link && !seen.has(link.label)) {
+      resolved.push(link);
+      seen.add(link.label);
+    }
+  }
+
+  if (resolved.length === 0) {
+    return AREA_LINKS;
+  }
+
+  return resolved;
+};
+
+const AreaLinks = ({ areas, className }: AreaLinksProps) => {
+  const links = useMemo(() => buildLinks(areas), [areas]);
+  const navClass = ['area-links', className].filter(Boolean).join(' ');
+
+  return (
+    <nav aria-label="Survey area shortcuts" className={navClass}>
+      <ul className="area-links__list">
+        {links.map((link) => (
+          <li className="area-links__item" key={`${link.label}-${link.outcode}`}>
+            <a className="area-links__pill" data-outcode={link.outcode} href={link.href}>
+              {link.label}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+};
+
+export default AreaLinks;

--- a/src/components/QuoteCalculator.tsx
+++ b/src/components/QuoteCalculator.tsx
@@ -1,0 +1,572 @@
+import type { FormEvent } from 'react';
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+} from 'react';
+
+import {
+  VAT_RATE,
+  calculateQuote,
+  describeOutcode,
+  estimateDistanceFromOutcode,
+  extractOutcode,
+  matchOutcodes,
+  normalisePostcode,
+  surveyTypes,
+  extraServiceList,
+  type ExtraService,
+  type OutcodeSuggestion,
+  type QuoteBreakdown,
+  type SurveyType,
+} from '../lib/pricing';
+import { getAreasForOutcode } from '../lib/areas';
+
+const FORM_ENDPOINT_PREFIX = 'https://formspree.io/f/';
+const DEFAULT_FORM_ID = 'xzzdqqqz';
+
+const formatCurrency = (value: number) =>
+  new Intl.NumberFormat('en-GB', {
+    style: 'currency',
+    currency: 'GBP',
+    minimumFractionDigits: value % 1 === 0 ? 0 : 2,
+    maximumFractionDigits: value % 1 === 0 ? 0 : 2,
+  }).format(value);
+
+const formatMiles = (distance: number) => `${distance.toFixed(1)} miles`;
+
+const getInitialOutcodeFromLocation = () => {
+  if (typeof window === 'undefined') {
+    return '';
+  }
+  const params = new URLSearchParams(window.location.search);
+  return params.get('outcode') ?? '';
+};
+
+const sendBeacon = (url: string, payload: Record<string, unknown>) => {
+  try {
+    const body = JSON.stringify(payload);
+    if (typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function') {
+      const blob = new Blob([body], { type: 'application/json' });
+      navigator.sendBeacon(url, blob);
+      return;
+    }
+
+    if (typeof fetch !== 'undefined') {
+      fetch(url, {
+        method: 'POST',
+        body,
+        headers: { 'Content-Type': 'application/json' },
+        keepalive: true,
+      }).catch(() => {
+        /* noop */
+      });
+    }
+  } catch (error) {
+    console.error('Quote beacon failed', error);
+  }
+};
+
+const sanitisePropertyValue = (value: string) => {
+  const cleaned = value.replace(/[^0-9.]/g, '');
+  if (!cleaned) return 0;
+  const parsed = Number.parseFloat(cleaned);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const sanitiseBedrooms = (value: string) => {
+  const cleaned = value.replace(/[^0-9]/g, '');
+  if (!cleaned) return 0;
+  const parsed = Number.parseInt(cleaned, 10);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+interface QuoteCalculatorProps {
+  formId?: string;
+  emailBeaconUrl?: string;
+  heading?: string;
+  description?: string;
+}
+
+type SubmissionStatus = 'idle' | 'success' | 'error';
+
+interface SubmissionResult {
+  status: SubmissionStatus;
+  message?: string;
+}
+
+const QuoteCalculator = ({
+  formId = DEFAULT_FORM_ID,
+  emailBeaconUrl = typeof import.meta !== 'undefined'
+    ? import.meta.env.PUBLIC_QUOTE_BEACON ?? undefined
+    : undefined,
+  heading = 'Instant Survey Estimate',
+  description = 'Enter a postcode and property details to generate an indicative fee. Submit the form to receive a tailored quote and availability from the surveyor.',
+}: QuoteCalculatorProps) => {
+  const idPrefix = useId();
+  const fieldId = useCallback((suffix: string) => `${idPrefix}-${suffix}`, [idPrefix]);
+
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [notes, setNotes] = useState('');
+
+  const [postcodeInput, setPostcodeInput] = useState(() => getInitialOutcodeFromLocation());
+  const [surveyType, setSurveyType] = useState<SurveyType>('level2');
+  const [bedroomInput, setBedroomInput] = useState('3');
+  const [propertyValueInput, setPropertyValueInput] = useState('250000');
+  const [selectedExtras, setSelectedExtras] = useState<ExtraService[]>([]);
+  const [isSubmitting, setSubmitting] = useState(false);
+  const [submission, setSubmission] = useState<SubmissionResult>({ status: 'idle' });
+
+  const bedrooms = useMemo(() => sanitiseBedrooms(bedroomInput), [bedroomInput]);
+  const propertyValue = useMemo(
+    () => sanitisePropertyValue(propertyValueInput),
+    [propertyValueInput],
+  );
+
+  const selectedOutcode = useMemo(
+    () => extractOutcode(postcodeInput ?? '') ?? '',
+    [postcodeInput],
+  );
+
+  const distanceMiles = useMemo(() => {
+    if (!selectedOutcode) return null;
+    return estimateDistanceFromOutcode(selectedOutcode);
+  }, [selectedOutcode]);
+
+  const quote = useMemo<QuoteBreakdown>(() => {
+    return calculateQuote({
+      surveyType,
+      bedrooms,
+      propertyValue,
+      distanceMiles,
+      extras: selectedExtras,
+    });
+  }, [surveyType, bedrooms, propertyValue, distanceMiles, selectedExtras]);
+
+  const suggestionQuery = postcodeInput.trim();
+  const rawSuggestions = useMemo(
+    () => matchOutcodes(suggestionQuery, 6),
+    [suggestionQuery],
+  );
+
+  const suggestions: OutcodeSuggestion[] = useMemo(() => {
+    if (!selectedOutcode) {
+      return rawSuggestions;
+    }
+    return rawSuggestions.filter((entry) => entry.outcode !== selectedOutcode);
+  }, [rawSuggestions, selectedOutcode]);
+
+  const shouldShowSuggestions =
+    (suggestionQuery.length >= 2 || !selectedOutcode) && suggestions.length > 0;
+
+  const outcodeDescription = useMemo(
+    () => (selectedOutcode ? describeOutcode(selectedOutcode) : null),
+    [selectedOutcode],
+  );
+
+  const areas = useMemo(
+    () => (selectedOutcode ? getAreasForOutcode(selectedOutcode) : []),
+    [selectedOutcode],
+  );
+
+  useEffect(() => {
+    if (submission.status !== 'idle') {
+      setSubmission({ status: 'idle' });
+    }
+  }, [
+    submission.status,
+    name,
+    email,
+    phone,
+    surveyType,
+    bedroomInput,
+    propertyValueInput,
+    postcodeInput,
+    notes,
+    selectedExtras,
+  ]);
+
+  const handleSelectSuggestion = useCallback((suggestion: OutcodeSuggestion) => {
+    setPostcodeInput(suggestion.outcode);
+  }, []);
+
+  const toggleExtra = useCallback((extra: ExtraService) => {
+    setSelectedExtras((current) => {
+      if (current.includes(extra)) {
+        return current.filter((item) => item !== extra);
+      }
+      return [...current, extra];
+    });
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (isSubmitting) return;
+      setSubmitting(true);
+      setSubmission({ status: 'idle' });
+
+      const normalisedPostcode = normalisePostcode(postcodeInput);
+      const areasServed = selectedOutcode ? getAreasForOutcode(selectedOutcode) : [];
+      const payloadExtras = selectedExtras.map((id) =>
+        extraServiceList.find((extra) => extra.id === id)?.label ?? id,
+      );
+
+      const formData = new FormData();
+      formData.set('name', name);
+      formData.set('email', email);
+      formData.set('contact', phone);
+      formData.set('postcode', normalisedPostcode);
+      if (selectedOutcode) {
+        formData.set('outcode', selectedOutcode);
+      }
+      formData.set('survey-type', surveyType);
+      formData.set('bedrooms', bedroomInput || String(bedrooms));
+      formData.set('property-value', propertyValueInput || String(propertyValue));
+      formData.set('calculated-quote', formatCurrency(quote.total));
+      formData.set('quote-net', formatCurrency(quote.net));
+      formData.set('quote-vat', formatCurrency(quote.vat));
+      formData.set('quote-distance-band', quote.distanceBand.label);
+      if (distanceMiles != null) {
+        formData.set('quote-distance-miles', distanceMiles.toFixed(2));
+      }
+      formData.set(
+        'quote-breakdown',
+        JSON.stringify({
+          base: quote.base,
+          bedroomAdjustment: quote.bedroomAdjustment,
+          valueAdjustment: quote.valueAdjustment,
+          distanceSurcharge: quote.distanceSurcharge,
+          extrasTotal: quote.extrasTotal,
+        }),
+      );
+      if (areasServed.length) {
+        formData.set('areas', areasServed.join(', '));
+      }
+      if (outcodeDescription) {
+        formData.set('outcode-description', outcodeDescription);
+      }
+      if (payloadExtras.length) {
+        formData.set('extras', payloadExtras.join(', '));
+      }
+      if (notes.trim()) {
+        formData.set('message', notes.trim());
+      }
+      formData.set('_subject', 'LEM Building Surveying quote calculator');
+
+      try {
+        const response = await fetch(`${FORM_ENDPOINT_PREFIX}${formId}`, {
+          method: 'POST',
+          body: formData,
+          headers: {
+            Accept: 'application/json',
+          },
+        });
+
+        if (!response.ok) {
+          throw new Error(`Form submission failed (${response.status})`);
+        }
+
+        setSubmitting(false);
+        setSubmission({
+          status: 'success',
+          message: 'Thanks! Your request has been sent. We will be in touch shortly.',
+        });
+
+        if (emailBeaconUrl) {
+          sendBeacon(emailBeaconUrl, {
+            name,
+            email,
+            phone,
+            postcode: normalisedPostcode,
+            outcode: selectedOutcode,
+            surveyType,
+            bedrooms,
+            propertyValue,
+            extras: payloadExtras,
+            quoteTotal: quote.total,
+            quoteNet: quote.net,
+            vat: quote.vat,
+          });
+        }
+      } catch (error) {
+        console.error(error);
+        setSubmitting(false);
+        setSubmission({
+          status: 'error',
+          message:
+            error instanceof Error
+              ? error.message
+              : 'Something went wrong. Please try again or email enquiries@lembuildingsurveying.co.uk.',
+        });
+      }
+    },
+    [
+      emailBeaconUrl,
+      formId,
+      isSubmitting,
+      name,
+      email,
+      phone,
+      postcodeInput,
+      selectedOutcode,
+      surveyType,
+      bedroomInput,
+      bedrooms,
+      propertyValueInput,
+      propertyValue,
+      quote,
+      distanceMiles,
+      notes,
+      selectedExtras,
+    ],
+  );
+
+  const distanceLabel = distanceMiles != null ? formatMiles(distanceMiles) : 'Unknown';
+
+  return (
+    <section className="quote-calculator" id="calculator">
+      <div className="quote-calculator__intro">
+        <h2>{heading}</h2>
+        <p>{description}</p>
+      </div>
+      <div className="quote-calculator__layout">
+        <form className="quote-calculator__form" onSubmit={handleSubmit} noValidate>
+          <div className="quote-calculator__grid">
+            <label className="quote-calculator__field" htmlFor={fieldId('name')}>
+              <span className="quote-calculator__label">Name</span>
+              <input
+                id={fieldId('name')}
+                name="name"
+                required
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                autoComplete="name"
+              />
+            </label>
+            <label className="quote-calculator__field" htmlFor={fieldId('email')}>
+              <span className="quote-calculator__label">Email</span>
+              <input
+                id={fieldId('email')}
+                name="email"
+                type="email"
+                required
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                autoComplete="email"
+              />
+            </label>
+            <label className="quote-calculator__field" htmlFor={fieldId('phone')}>
+              <span className="quote-calculator__label">Contact number</span>
+              <input
+                id={fieldId('phone')}
+                name="contact"
+                type="tel"
+                required
+                value={phone}
+                onChange={(event) => setPhone(event.target.value)}
+                autoComplete="tel"
+              />
+            </label>
+            <div className="quote-calculator__field">
+              <label className="quote-calculator__label" htmlFor={fieldId('postcode')}>
+                Postcode or area
+              </label>
+              <input
+                id={fieldId('postcode')}
+                name="postcode"
+                value={postcodeInput}
+                onChange={(event) => setPostcodeInput(event.target.value.toUpperCase())}
+                placeholder="e.g. CH5 1AB or Connahs Quay"
+                autoComplete="postal-code"
+                required
+              />
+              {shouldShowSuggestions && (
+                <ul className="quote-calculator__suggestions" role="listbox">
+                  {suggestions.map((suggestion) => (
+                    <li key={suggestion.outcode}>
+                      <button
+                        type="button"
+                        className="quote-calculator__suggestion"
+                        onClick={() => handleSelectSuggestion(suggestion)}
+                      >
+                        <span className="quote-calculator__suggestion-code">
+                          {suggestion.outcode}
+                        </span>
+                        <span className="quote-calculator__suggestion-label">
+                          {suggestion.label}
+                        </span>
+                        <span className="quote-calculator__suggestion-distance">
+                          {formatMiles(suggestion.distanceMiles)}
+                        </span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+            <label className="quote-calculator__field" htmlFor={fieldId('survey-type')}>
+              <span className="quote-calculator__label">Survey type</span>
+              <select
+                id={fieldId('survey-type')}
+                name="survey-type"
+                value={surveyType}
+                onChange={(event) => setSurveyType(event.target.value as SurveyType)}
+                required
+              >
+                {surveyTypes.map((survey) => (
+                  <option key={survey.id} value={survey.id}>
+                    {survey.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="quote-calculator__field" htmlFor={fieldId('bedrooms')}>
+              <span className="quote-calculator__label">Bedrooms</span>
+              <input
+                id={fieldId('bedrooms')}
+                inputMode="numeric"
+                min={0}
+                name="bedrooms"
+                type="number"
+                value={bedroomInput}
+                onChange={(event) => setBedroomInput(event.target.value)}
+              />
+            </label>
+            <label className="quote-calculator__field" htmlFor={fieldId('value')}>
+              <span className="quote-calculator__label">Estimated property value (£)</span>
+              <input
+                id={fieldId('value')}
+                inputMode="decimal"
+                min={0}
+                name="property-value"
+                type="number"
+                value={propertyValueInput}
+                onChange={(event) => setPropertyValueInput(event.target.value)}
+                step="1000"
+              />
+            </label>
+          </div>
+
+          <fieldset className="quote-calculator__extras">
+            <legend>Optional extras</legend>
+            {extraServiceList.map((extra) => {
+              const checked = selectedExtras.includes(extra.id);
+              return (
+                <label key={extra.id} className="quote-calculator__checkbox">
+                  <input
+                    type="checkbox"
+                    name="extras"
+                    value={extra.id}
+                    checked={checked}
+                    onChange={() => toggleExtra(extra.id)}
+                  />
+                  <span>
+                    <strong>{extra.label}</strong>
+                    <br />
+                    <small>
+                      {extra.description} ({formatCurrency(extra.price)})
+                    </small>
+                  </span>
+                </label>
+              );
+            })}
+          </fieldset>
+
+          <label className="quote-calculator__field" htmlFor={fieldId('notes')}>
+            <span className="quote-calculator__label">Additional information (optional)</span>
+            <textarea
+              id={fieldId('notes')}
+              name="message"
+              rows={4}
+              value={notes}
+              onChange={(event) => setNotes(event.target.value)}
+            />
+          </label>
+
+          <button className="quote-calculator__submit" disabled={isSubmitting} type="submit">
+            {isSubmitting ? 'Sending…' : 'Request my tailored quote'}
+          </button>
+
+          {submission.status === 'success' && (
+            <p className="quote-calculator__status quote-calculator__status--success">
+              {submission.message}
+            </p>
+          )}
+          {submission.status === 'error' && (
+            <p className="quote-calculator__status quote-calculator__status--error">
+              {submission.message}
+            </p>
+          )}
+        </form>
+
+        <aside className="quote-calculator__summary">
+          <h3>Estimated total</h3>
+          <p className="quote-calculator__total">{formatCurrency(quote.total)}</p>
+          <p className="quote-calculator__note">
+            Inclusive of VAT at {Math.round(VAT_RATE * 100)}%. Net fee {formatCurrency(quote.net)} +
+            VAT {formatCurrency(quote.vat)}.
+          </p>
+          <dl className="quote-calculator__breakdown">
+            <div>
+              <dt>Base survey fee</dt>
+              <dd>{formatCurrency(quote.base)}</dd>
+            </div>
+            {quote.bedroomAdjustment > 0 && (
+              <div>
+                <dt>Bedrooms adjustment</dt>
+                <dd>{formatCurrency(quote.bedroomAdjustment)}</dd>
+              </div>
+            )}
+            {quote.valueAdjustment > 0 && (
+              <div>
+                <dt>Property value band</dt>
+                <dd>{formatCurrency(quote.valueAdjustment)}</dd>
+              </div>
+            )}
+            {quote.distanceSurcharge > 0 && (
+              <div>
+                <dt>Travel supplement</dt>
+                <dd>{formatCurrency(quote.distanceSurcharge)}</dd>
+              </div>
+            )}
+            {quote.extrasTotal > 0 && (
+              <div>
+                <dt>Extras</dt>
+                <dd>{formatCurrency(quote.extrasTotal)}</dd>
+              </div>
+            )}
+          </dl>
+
+          <div className="quote-calculator__meta">
+            <p>
+              <strong>Distance band:</strong> {quote.distanceBand.label}
+              {distanceMiles != null && ` (${distanceLabel})`}
+            </p>
+            {areas.length > 0 && (
+              <p>
+                <strong>Local coverage:</strong>{' '}
+                {areas.map((area, index) => (
+                  <Fragment key={area}>
+                    {area}
+                    {index < areas.length - 1 ? ', ' : ''}
+                  </Fragment>
+                ))}
+              </p>
+            )}
+            {outcodeDescription && (
+              <p className="quote-calculator__outcode">{outcodeDescription}</p>
+            )}
+          </div>
+        </aside>
+      </div>
+    </section>
+  );
+};
+
+export default QuoteCalculator;

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,9 @@
 /// <reference path="../.astro/types.d.ts" />
+
+interface ImportMetaEnv {
+  readonly PUBLIC_QUOTE_BEACON?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/src/lib/areas.ts
+++ b/src/lib/areas.ts
@@ -1,0 +1,109 @@
+export interface AreaConfig {
+  label: string;
+  outcode: string;
+  aliases?: string[];
+}
+
+export interface AreaLink {
+  label: string;
+  outcode: string;
+  href: string;
+}
+
+const AREA_CONFIG: AreaConfig[] = [
+  {
+    label: 'Connah’s Quay',
+    outcode: 'CH5',
+    aliases: [
+      'Connahs Quay',
+      "Connah's Quay",
+      'Deeside',
+      'Shotton',
+      'Queensferry',
+      'Hawarden',
+      'Ewloe',
+      'Sandycroft',
+    ],
+  },
+  { label: 'Flint', outcode: 'CH6', aliases: ['Oakenholt', 'Bagillt'] },
+  { label: 'Buckley', outcode: 'CH7', aliases: ['Drury', 'Mynydd Isa'] },
+  { label: 'Mold', outcode: 'CH7', aliases: ['New Brighton', 'Sychdyn'] },
+  { label: 'Broughton', outcode: 'CH4', aliases: ['Bretton'] },
+  { label: 'Saltney', outcode: 'CH4' },
+  { label: 'Hawarden', outcode: 'CH5', aliases: ['Mancot', 'Aston Hill'] },
+  { label: 'Ewloe', outcode: 'CH5' },
+  { label: 'Northop Hall', outcode: 'CH7', aliases: ['Northop Hall Village'] },
+  { label: 'Northop', outcode: 'CH7', aliases: ['Sychdyn', 'New Brighton'] },
+  { label: 'Oakenholt', outcode: 'CH6' },
+  { label: 'Shotton', outcode: 'CH5' },
+  { label: 'Queensferry', outcode: 'CH5' },
+  { label: 'Tarporley', outcode: 'CW6', aliases: ['Kelsall', 'Cotebrook'] },
+  { label: 'Waverton', outcode: 'CH3', aliases: ['Saighton', 'Huntington'] },
+  { label: 'Hoole', outcode: 'CH2', aliases: ['Upton', 'Newton'] },
+  { label: 'Boughton', outcode: 'CH3' },
+  { label: 'Vicars Cross', outcode: 'CH3', aliases: ['Guilden Sutton'] },
+  { label: 'Chester', outcode: 'CH1', aliases: ['Handbridge', 'Curzon Park', 'City Centre'] },
+  { label: 'Higher Kinnerton', outcode: 'CH4', aliases: ['Lower Kinnerton'] },
+  { label: 'Pulford', outcode: 'CH4', aliases: ['Dodleston'] },
+  { label: 'Rossett', outcode: 'LL12', aliases: ['Marford', 'Gresford', 'Llay'] },
+  { label: 'Tarvin', outcode: 'CH3', aliases: ['Christleton', 'Tattenhall', 'Huxley'] },
+  { label: 'Aldford', outcode: 'CH3', aliases: ['Farndon'] },
+  { label: 'Sandycroft', outcode: 'CH5', aliases: ['Penyffordd'] },
+  { label: 'Holywell', outcode: 'CH8', aliases: ['Greenfield', 'Mostyn', 'Carmel'] },
+  { label: 'Malpas', outcode: 'SY14', aliases: ['Tilston', 'Threapwood', 'Shocklach'] },
+  { label: 'Whitchurch', outcode: 'SY13', aliases: ['Ash', 'Alkington'] },
+  { label: 'Holt', outcode: 'LL13', aliases: ['Bangor-on-Dee'] },
+  { label: 'Ruabon', outcode: 'LL14', aliases: ['Cefn Mawr', 'Rhosllanerchrugog'] },
+  { label: 'Neston', outcode: 'CH64', aliases: ['Parkgate', 'Little Neston', 'Willaston'] },
+  { label: 'Ellesmere Port', outcode: 'CH65', aliases: ['Whitby', 'Overpool'] },
+  { label: 'Great Sutton', outcode: 'CH66', aliases: ['Little Sutton', 'Childer Thornton'] },
+  { label: 'Heswall', outcode: 'CH60', aliases: ['Gayton'] },
+  { label: 'Bebington', outcode: 'CH63', aliases: ['Thornton Hough', 'Clatterbridge'] },
+  { label: 'Bromborough', outcode: 'CH62', aliases: ['Port Sunlight', 'Spital'] },
+  { label: 'Frodsham', outcode: 'WA6', aliases: ['Helsby', 'Kingsley'] },
+  { label: 'Runcorn', outcode: 'WA7', aliases: ['Sandymoor', 'Preston Brook'] },
+  { label: 'Widnes', outcode: 'WA8', aliases: ['Cronton', 'Hough Green'] },
+];
+
+const normalise = (value: string) => value.trim().toLowerCase().replace(/[’']/g, '');
+
+const areaLookup = new Map<string, AreaConfig>();
+const outcodeLookup = new Map<string, string[]>();
+
+for (const config of AREA_CONFIG) {
+  const key = normalise(config.label);
+  areaLookup.set(key, config);
+
+  if (config.aliases) {
+    for (const alias of config.aliases) {
+      areaLookup.set(normalise(alias), config);
+    }
+  }
+
+  const existing = outcodeLookup.get(config.outcode) ?? [];
+  existing.push(config.label);
+  outcodeLookup.set(config.outcode, existing);
+}
+
+export function getOutcodeForArea(area: string): string | undefined {
+  return areaLookup.get(normalise(area))?.outcode;
+}
+
+export function findAreaConfig(area: string): AreaConfig | undefined {
+  return areaLookup.get(normalise(area));
+}
+
+export function getAreasForOutcode(outcode: string): string[] {
+  return [...(outcodeLookup.get(outcode.toUpperCase()) ?? [])];
+}
+
+export const AREA_LINKS: AreaLink[] = AREA_CONFIG.map((config) => ({
+  label: config.label,
+  outcode: config.outcode,
+  href: `/quote?outcode=${encodeURIComponent(config.outcode)}#calculator`,
+}));
+
+export const AREA_OUTCODE_MAP = AREA_CONFIG.reduce<Record<string, string>>((acc, config) => {
+  acc[config.label] = config.outcode;
+  return acc;
+}, {});

--- a/src/lib/pricing.test.ts
+++ b/src/lib/pricing.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  VAT_RATE,
+  calculateDistanceBand,
+  calculateQuote,
+  describeOutcode,
+  estimateDistanceFromOutcode,
+  extractOutcode,
+  matchOutcodes,
+  normalisePostcode,
+} from './pricing';
+
+describe('postcode utilities', () => {
+  it('normalises postcode spacing and case', () => {
+    expect(normalisePostcode(' ch5\t1ab ')).toBe('CH5 1AB');
+    expect(normalisePostcode('cw60aa')).toBe('CW6 0AA');
+  });
+
+  it('extracts the outcode from full postcodes', () => {
+    expect(extractOutcode('ch5 1ab')).toBe('CH5');
+    expect(extractOutcode('CW60aa')).toBe('CW6');
+    expect(extractOutcode('l1 2ab')).toBe('L1');
+    expect(extractOutcode('not-a-postcode')).toBeNull();
+  });
+});
+
+describe('distance helpers', () => {
+  it('estimates distance from known outcodes', () => {
+    expect(estimateDistanceFromOutcode('CH6')).toBeCloseTo(5.27, 2);
+    expect(estimateDistanceFromOutcode('CW6')).toBeCloseTo(15.79, 2);
+    expect(estimateDistanceFromOutcode('SY13')).toBeCloseTo(22.74, 2);
+    expect(estimateDistanceFromOutcode('ZZ99')).toBeNull();
+  });
+
+  it('returns the correct distance band', () => {
+    expect(calculateDistanceBand(4).id).toBe('local');
+    expect(calculateDistanceBand(14).id).toBe('nearby');
+    expect(calculateDistanceBand(28).id).toBe('regional');
+    expect(calculateDistanceBand(48).id).toBe('extended');
+    expect(calculateDistanceBand(undefined).id).toBe('extended');
+  });
+});
+
+describe('outcode matching', () => {
+  it('matches on outcode labels and aliases', () => {
+    const results = matchOutcodes('tarporley');
+    expect(results[0]?.outcode).toBe('CW6');
+    expect(results.length).toBeGreaterThan(0);
+  });
+
+  it('falls back to local outcodes when query empty', () => {
+    const results = matchOutcodes('');
+    expect(results).toHaveLength(6);
+    expect(results[0].outcode).toBe('CH5');
+  });
+});
+
+describe('quote calculation', () => {
+  it('calculates totals with VAT and extras', () => {
+    const quote = calculateQuote({
+      surveyType: 'level2',
+      bedrooms: 3,
+      propertyValue: 325_000,
+      distanceMiles: 8,
+      extras: ['valuation', 'thermal'],
+    });
+
+    expect(quote.base).toBe(475);
+    expect(quote.bedroomAdjustment).toBe(45);
+    expect(quote.valueAdjustment).toBe(35);
+    expect(quote.distanceSurcharge).toBe(0);
+    expect(quote.extrasTotal).toBe(235);
+    expect(quote.net).toBe(790);
+    expect(quote.vat).toBeCloseTo(quote.net * VAT_RATE, 5);
+    expect(quote.total).toBe(948);
+    expect(quote.distanceBand.id).toBe('local');
+    expect(quote.appliedExtras.map((extra) => extra.id)).toEqual([
+      'valuation',
+      'thermal',
+    ]);
+  });
+
+  it('applies fallback distance when not provided', () => {
+    const quote = calculateQuote({
+      surveyType: 'level1',
+      bedrooms: 2,
+      propertyValue: 800_000,
+      distanceMiles: null,
+      extras: [],
+    });
+
+    expect(quote.base).toBe(350);
+    expect(quote.bedroomAdjustment).toBe(0);
+    expect(quote.valueAdjustment).toBe(165);
+    expect(quote.distanceSurcharge).toBe(55);
+    expect(quote.net).toBe(570);
+    expect(quote.total).toBe(684);
+    expect(quote.distanceBand.id).toBe('extended');
+  });
+
+  it('describes known outcodes', () => {
+    expect(describeOutcode('CH4')).toContain('Broughton');
+    expect(describeOutcode('ZZ99')).toBeNull();
+  });
+});

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -1,0 +1,668 @@
+export const VAT_RATE = 0.2;
+
+export interface DistanceBand {
+  id: string;
+  label: string;
+  minDistance: number;
+  maxDistance: number;
+  surcharge: number;
+}
+
+const DISTANCE_BANDS: DistanceBand[] = [
+  {
+    id: 'local',
+    label: 'Local (0–10 miles)',
+    minDistance: 0,
+    maxDistance: 10,
+    surcharge: 0,
+  },
+  {
+    id: 'nearby',
+    label: 'Nearby (10–20 miles)',
+    minDistance: 10,
+    maxDistance: 20,
+    surcharge: 20,
+  },
+  {
+    id: 'regional',
+    label: 'Regional (20–35 miles)',
+    minDistance: 20,
+    maxDistance: 35,
+    surcharge: 35,
+  },
+  {
+    id: 'extended',
+    label: 'Extended (35+ miles)',
+    minDistance: 35,
+    maxDistance: Number.POSITIVE_INFINITY,
+    surcharge: 55,
+  },
+];
+
+const DEFAULT_DISTANCE_BAND = DISTANCE_BANDS[DISTANCE_BANDS.length - 1];
+
+export const distanceBands = [...DISTANCE_BANDS];
+
+export const BASE_LOCATION = {
+  outcode: 'CH5',
+  label: 'Connah’s Quay & Deeside',
+  latitude: 53.204347497391296,
+  longitude: -3.041531686086955,
+};
+
+export interface SurveyPricingTier {
+  label: string;
+  basePrice: number;
+  bedroomPremium: number;
+}
+
+export const SURVEY_PRICING: Record<string, SurveyPricingTier> = {
+  level1: {
+    label: 'Level 1 — Condition Report',
+    basePrice: 350,
+    bedroomPremium: 30,
+  },
+  level2: {
+    label: 'Level 2 — HomeBuyer Survey',
+    basePrice: 475,
+    bedroomPremium: 45,
+  },
+  level3: {
+    label: 'Level 3 — Building Survey',
+    basePrice: 650,
+    bedroomPremium: 65,
+  },
+  damp: {
+    label: 'Independent Damp Survey',
+    basePrice: 275,
+    bedroomPremium: 20,
+  },
+};
+
+export type SurveyType = keyof typeof SURVEY_PRICING;
+
+export interface ExtraServiceConfig {
+  label: string;
+  description: string;
+  price: number;
+}
+
+export const EXTRA_SERVICES: Record<string, ExtraServiceConfig> = {
+  valuation: {
+    label: 'RICS Market Valuation',
+    description: 'Formal valuation carried out alongside the survey.',
+    price: 140,
+  },
+  thermal: {
+    label: 'Thermal Imaging Scan',
+    description: 'Infrared assessment highlighting heat loss and insulation issues.',
+    price: 95,
+  },
+  damp: {
+    label: 'Independent Damp Report',
+    description: 'Expanded moisture diagnostics with salt analysis and recommendations.',
+    price: 110,
+  },
+};
+
+export type ExtraService = keyof typeof EXTRA_SERVICES;
+
+interface PropertyValueBand {
+  maxValue: number;
+  addition: number;
+}
+
+const PROPERTY_VALUE_BANDS: PropertyValueBand[] = [
+  { maxValue: 275_000, addition: 0 },
+  { maxValue: 400_000, addition: 35 },
+  { maxValue: 550_000, addition: 75 },
+  { maxValue: 750_000, addition: 110 },
+  { maxValue: Number.POSITIVE_INFINITY, addition: 165 },
+];
+
+export const propertyValueBands = [...PROPERTY_VALUE_BANDS];
+
+export interface QuoteOptions {
+  surveyType: SurveyType;
+  bedrooms: number;
+  propertyValue: number;
+  distanceMiles?: number | null;
+  extras?: ExtraService[];
+}
+
+export interface QuoteBreakdown {
+  base: number;
+  bedroomAdjustment: number;
+  valueAdjustment: number;
+  distanceSurcharge: number;
+  extrasTotal: number;
+  net: number;
+  vat: number;
+  total: number;
+  distanceBand: DistanceBand;
+  appliedExtras: Array<{ id: ExtraService; label: string; price: number }>;
+}
+
+export interface OutcodeMetadata {
+  outcode: string;
+  label: string;
+  latitude: number;
+  longitude: number;
+  priority: number;
+  areas: string[];
+}
+
+export interface OutcodeSuggestion extends OutcodeMetadata {
+  distanceMiles: number;
+}
+
+const OUTCODE_METADATA: Record<string, OutcodeMetadata> = {
+  CH5: {
+    outcode: 'CH5',
+    label: 'Connah’s Quay, Shotton & Deeside',
+    latitude: 53.204347497391296,
+    longitude: -3.041531686086955,
+    priority: 0,
+    areas: [
+      'Connah’s Quay',
+      'Connahs Quay',
+      "Connah's Quay",
+      'Shotton',
+      'Queensferry',
+      'Sealand',
+      'Hawarden',
+      'Ewloe',
+      'Sandycroft',
+      'Garden City',
+      'Penyffordd',
+      'Mancot',
+      'Deeside',
+    ],
+  },
+  CH6: {
+    outcode: 'CH6',
+    label: 'Flint, Oakenholt & Bagillt',
+    latitude: 53.249369818385595,
+    longitude: -3.1444829977578497,
+    priority: 1,
+    areas: ['Flint', 'Oakenholt', 'Bagillt', 'Pentre Halkyn', 'Flint Mountain'],
+  },
+  CH7: {
+    outcode: 'CH7',
+    label: 'Buckley, Mold & Northop',
+    latitude: 53.17003717969733,
+    longitude: -3.1321611967213103,
+    priority: 1,
+    areas: [
+      'Buckley',
+      'Mold',
+      'Northop',
+      'Northop Hall',
+      'Sychdyn',
+      'New Brighton',
+      'Penyffordd',
+      'Drury',
+      'Alltami',
+    ],
+  },
+  CH4: {
+    outcode: 'CH4',
+    label: 'Broughton, Saltney & Kinnerton',
+    latitude: 53.16547435043666,
+    longitude: -2.947423124454147,
+    priority: 1,
+    areas: [
+      'Broughton',
+      'Saltney',
+      'Higher Kinnerton',
+      'Lower Kinnerton',
+      'Dodleston',
+      'Pulford',
+      'Bretton',
+      'Curzon Park',
+      'Handbridge',
+      'Lache',
+    ],
+  },
+  CH3: {
+    outcode: 'CH3',
+    label: 'Waverton, Boughton & Vicars Cross',
+    latitude: 53.164654851351365,
+    longitude: -2.819672681981981,
+    priority: 1,
+    areas: [
+      'Waverton',
+      'Boughton',
+      'Vicars Cross',
+      'Guilden Sutton',
+      'Saighton',
+      'Tarvin',
+      'Christleton',
+      'Huntington',
+      'Aldford',
+      'Farndon',
+      'Tattenhall',
+      'Huxley',
+    ],
+  },
+  CH2: {
+    outcode: 'CH2',
+    label: 'Hoole, Upton & Newton',
+    latitude: 53.21805359788968,
+    longitude: -2.86898953692849,
+    priority: 1,
+    areas: ['Hoole', 'Upton', 'Newton', 'Mickle Trafford', 'Moston'],
+  },
+  CH1: {
+    outcode: 'CH1',
+    label: 'Chester City, Blacon & Saughall',
+    latitude: 53.202623356537856,
+    longitude: -2.909792639698939,
+    priority: 1,
+    areas: ['Chester', 'Blacon', 'Sealand', 'Saughall', 'City Centre'],
+  },
+  CH8: {
+    outcode: 'CH8',
+    label: 'Holywell, Greenfield & Halkyn',
+    latitude: 53.282993727138674,
+    longitude: -3.2463595265486744,
+    priority: 2,
+    areas: ['Holywell', 'Greenfield', 'Mostyn', 'Halkyn', 'Pentre Halkyn', 'Carmel'],
+  },
+  CW6: {
+    outcode: 'CW6',
+    label: 'Tarporley, Kelsall & Bunbury',
+    latitude: 53.16219869244601,
+    longitude: -2.666821534172662,
+    priority: 2,
+    areas: ['Tarporley', 'Kelsall', 'Bunbury', 'Utkinton', 'Cotebrook', 'Tilstone Fearnall'],
+  },
+  LL12: {
+    outcode: 'LL12',
+    label: 'Rossett, Marford & Gresford',
+    latitude: 53.087830759864715,
+    longitude: -2.9889996967305543,
+    priority: 2,
+    areas: ['Rossett', 'Marford', 'Gresford', 'Llay', 'Cefn-y-bedd'],
+  },
+  LL13: {
+    outcode: 'LL13',
+    label: 'Holt, Farndon & Wrexham South',
+    latitude: 53.03439246775747,
+    longitude: -2.9587070827718907,
+    priority: 2,
+    areas: ['Holt', 'Farndon', 'Marchwiel', 'Bangor-on-Dee', 'Abenbury'],
+  },
+  LL14: {
+    outcode: 'LL14',
+    label: 'Ruabon, Rhos & Cefn Mawr',
+    latitude: 52.99118173896352,
+    longitude: -3.0531495690978923,
+    priority: 3,
+    areas: ['Ruabon', 'Rhosllanerchrugog', 'Johnstown', 'Cefn Mawr', 'Acrefair'],
+  },
+  LL11: {
+    outcode: 'LL11',
+    label: 'Brymbo, Gwersyllt & Pentre Broughton',
+    latitude: 53.06358892366995,
+    longitude: -3.0363657733230496,
+    priority: 3,
+    areas: ['Brymbo', 'Gwersyllt', 'Tanyfron', 'Pentre Broughton'],
+  },
+  CH65: {
+    outcode: 'CH65',
+    label: 'Ellesmere Port Town Centre',
+    latitude: 53.27740971289539,
+    longitude: -2.9019708953771244,
+    priority: 3,
+    areas: ['Ellesmere Port', 'Whitby', 'Overpool', 'Stanney Oaks'],
+  },
+  CH66: {
+    outcode: 'CH66',
+    label: 'Great Sutton & Little Sutton',
+    latitude: 53.27759118319832,
+    longitude: -2.937158060728748,
+    priority: 3,
+    areas: ['Great Sutton', 'Little Sutton', 'Childer Thornton', 'Ledsham'],
+  },
+  CH64: {
+    outcode: 'CH64',
+    label: 'Neston, Parkgate & Willaston',
+    latitude: 53.2882811604361,
+    longitude: -3.0475894937694665,
+    priority: 3,
+    areas: ['Neston', 'Parkgate', 'Little Neston', 'Willaston', 'Burton'],
+  },
+  CH60: {
+    outcode: 'CH60',
+    label: 'Heswall & Gayton',
+    latitude: 53.32650133188723,
+    longitude: -3.096076598698483,
+    priority: 4,
+    areas: ['Heswall', 'Gayton', 'Lower Heswall'],
+  },
+  CH61: {
+    outcode: 'CH61',
+    label: 'Thingwall, Pensby & Irby',
+    latitude: 53.3491502870813,
+    longitude: -3.1019839162679457,
+    priority: 4,
+    areas: ['Thingwall', 'Pensby', 'Irby', 'Barnston'],
+  },
+  CH62: {
+    outcode: 'CH62',
+    label: 'Bromborough, Spital & Port Sunlight',
+    latitude: 53.334181898780514,
+    longitude: -2.9815520414634147,
+    priority: 4,
+    areas: ['Bromborough', 'Spital', 'Port Sunlight'],
+  },
+  CH63: {
+    outcode: 'CH63',
+    label: 'Bebington & Thornton Hough',
+    latitude: 53.34426920777646,
+    longitude: -3.0125221227217507,
+    priority: 4,
+    areas: ['Bebington', 'Higher Bebington', 'Thornton Hough', 'Clatterbridge'],
+  },
+  WA6: {
+    outcode: 'WA6',
+    label: 'Frodsham & Helsby',
+    latitude: 53.272597193846195,
+    longitude: -2.724793174358977,
+    priority: 3,
+    areas: ['Frodsham', 'Helsby', 'Kingsley', 'Alvanley'],
+  },
+  WA7: {
+    outcode: 'WA7',
+    label: 'Runcorn & Sandymoor',
+    latitude: 53.33067586653512,
+    longitude: -2.7030976226166956,
+    priority: 4,
+    areas: ['Runcorn', 'Sandymoor', 'Norton', 'Preston Brook'],
+  },
+  WA8: {
+    outcode: 'WA8',
+    label: 'Widnes & Cronton',
+    latitude: 53.37312734766118,
+    longitude: -2.741418227560046,
+    priority: 4,
+    areas: ['Widnes', 'Cronton', 'Hough Green', 'Ditton'],
+  },
+  SY14: {
+    outcode: 'SY14',
+    label: 'Malpas, Tilston & Threapwood',
+    latitude: 53.03142412356321,
+    longitude: -2.7681025172413807,
+    priority: 4,
+    areas: ['Malpas', 'Tilston', 'Threapwood', 'No Man’s Heath', 'Shocklach'],
+  },
+  SY13: {
+    outcode: 'SY13',
+    label: 'Whitchurch & Border Villages',
+    latitude: 52.95203578774124,
+    longitude: -2.6896400215664036,
+    priority: 5,
+    areas: ['Whitchurch', 'Prees Heath', 'Ash', 'Alkington'],
+  },
+};
+
+const OUTCODE_LIST: OutcodeMetadata[] = Object.values(OUTCODE_METADATA);
+
+const EARTH_RADIUS_MILES = 3958.8;
+
+const toRadians = (degrees: number) => (degrees * Math.PI) / 180;
+
+function haversineDistanceMiles(
+  startLat: number,
+  startLon: number,
+  targetLat: number,
+  targetLon: number,
+): number {
+  const dLat = toRadians(targetLat - startLat);
+  const dLon = toRadians(targetLon - startLon);
+  const rLat1 = toRadians(startLat);
+  const rLat2 = toRadians(targetLat);
+
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(rLat1) * Math.cos(rLat2) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return EARTH_RADIUS_MILES * c;
+}
+
+const distanceCache = new Map<string, number>();
+
+function distanceFromBase(outcode: string): number {
+  const cached = distanceCache.get(outcode);
+  if (typeof cached === 'number') {
+    return cached;
+  }
+
+  const meta = OUTCODE_METADATA[outcode];
+  if (!meta) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  const distance = haversineDistanceMiles(
+    BASE_LOCATION.latitude,
+    BASE_LOCATION.longitude,
+    meta.latitude,
+    meta.longitude,
+  );
+  const rounded = roundToTwoDecimals(distance);
+  distanceCache.set(outcode, rounded);
+  return rounded;
+}
+
+export function getOutcodeMetadata(outcode: string): OutcodeMetadata | undefined {
+  return OUTCODE_METADATA[normaliseOutcode(outcode)];
+}
+
+export function calculateDistanceBand(distanceMiles?: number | null): DistanceBand {
+  if (!Number.isFinite(distanceMiles ?? NaN)) {
+    return DEFAULT_DISTANCE_BAND;
+  }
+
+  const safeDistance = Math.max(0, Number(distanceMiles));
+  for (const band of DISTANCE_BANDS) {
+    if (safeDistance >= band.minDistance && safeDistance <= band.maxDistance) {
+      return band;
+    }
+  }
+
+  return DEFAULT_DISTANCE_BAND;
+}
+
+function bedroomAdjustmentFor(type: SurveyType, bedrooms: number): number {
+  const config = SURVEY_PRICING[type];
+  const safeBedrooms = Number.isFinite(bedrooms) ? Math.max(0, Math.floor(bedrooms)) : 0;
+  const premiumableBedrooms = Math.max(0, safeBedrooms - 2);
+  return premiumableBedrooms * config.bedroomPremium;
+}
+
+function propertyValueAdjustment(propertyValue: number): number {
+  const safeValue = Number.isFinite(propertyValue) ? Math.max(0, propertyValue) : 0;
+  for (const band of PROPERTY_VALUE_BANDS) {
+    if (safeValue <= band.maxValue) {
+      return band.addition;
+    }
+  }
+  return 0;
+}
+
+function extrasBreakdown(extras: ExtraService[] | undefined) {
+  const uniqueExtras = [...new Set(extras ?? [])];
+  const applied: Array<{ id: ExtraService; label: string; price: number }> = [];
+  let total = 0;
+
+  for (const id of uniqueExtras) {
+    const config = EXTRA_SERVICES[id];
+    if (!config) continue;
+    total += config.price;
+    applied.push({ id, label: config.label, price: config.price });
+  }
+
+  return { applied, total };
+}
+
+function roundToTwoDecimals(value: number): number {
+  return Math.round((Number.isFinite(value) ? value : 0) * 100) / 100;
+}
+
+export function calculateQuote(options: QuoteOptions): QuoteBreakdown {
+  const survey = SURVEY_PRICING[options.surveyType];
+  if (!survey) {
+    throw new Error(`Unsupported survey type: ${options.surveyType}`);
+  }
+
+  const base = survey.basePrice;
+  const bedroomAdjustment = bedroomAdjustmentFor(options.surveyType, options.bedrooms);
+  const valueAdjustment = propertyValueAdjustment(options.propertyValue);
+
+  const distanceBand = calculateDistanceBand(options.distanceMiles);
+  const distanceSurcharge = distanceBand.surcharge;
+
+  const { applied: appliedExtras, total: extrasTotal } = extrasBreakdown(options.extras);
+
+  const net = roundToTwoDecimals(
+    base + bedroomAdjustment + valueAdjustment + distanceSurcharge + extrasTotal,
+  );
+  const vat = roundToTwoDecimals(net * VAT_RATE);
+  const total = roundToTwoDecimals(net + vat);
+
+  return {
+    base,
+    bedroomAdjustment: roundToTwoDecimals(bedroomAdjustment),
+    valueAdjustment: roundToTwoDecimals(valueAdjustment),
+    distanceSurcharge: roundToTwoDecimals(distanceSurcharge),
+    extrasTotal: roundToTwoDecimals(extrasTotal),
+    net,
+    vat,
+    total,
+    distanceBand,
+    appliedExtras,
+  };
+}
+
+export function normalisePostcode(input: string): string {
+  const trimmed = input.trim().toUpperCase();
+  if (!trimmed) return '';
+  const collapsed = trimmed.replace(/\s+/g, '');
+  if (collapsed.length <= 3) {
+    return collapsed;
+  }
+  const outward = collapsed.slice(0, collapsed.length - 3);
+  const inward = collapsed.slice(-3);
+  return `${outward} ${inward}`;
+}
+
+const OUTCODE_PATTERN = /^([A-Z]{1,2}\d[A-Z\d]?)/;
+
+export function extractOutcode(postcode: string): string | null {
+  const normalised = normalisePostcode(postcode);
+  const match = normalised.match(OUTCODE_PATTERN);
+  if (!match) {
+    return null;
+  }
+  return match[1] ?? null;
+}
+
+function normaliseOutcode(outcode: string): string {
+  return outcode.trim().toUpperCase();
+}
+
+export function estimateDistanceFromOutcode(outcode: string): number | null {
+  const normalised = normaliseOutcode(outcode);
+  if (!OUTCODE_METADATA[normalised]) {
+    return null;
+  }
+  return distanceFromBase(normalised);
+}
+
+export function describeOutcode(outcode: string): string | null {
+  const meta = getOutcodeMetadata(outcode);
+  return meta?.label ?? null;
+}
+
+export function matchOutcodes(query: string, limit = 6): OutcodeSuggestion[] {
+  const cleanedQuery = query.trim().toLowerCase();
+  const baseList = OUTCODE_LIST.map((meta) => ({
+    meta,
+    distance: distanceFromBase(meta.outcode),
+  }));
+
+  if (!cleanedQuery) {
+    return baseList
+      .sort((a, b) => {
+        if (a.meta.priority !== b.meta.priority) {
+          return a.meta.priority - b.meta.priority;
+        }
+        if (a.distance !== b.distance) {
+          return a.distance - b.distance;
+        }
+        return a.meta.outcode.localeCompare(b.meta.outcode);
+      })
+      .slice(0, limit)
+      .map(({ meta, distance }) => ({ ...meta, distanceMiles: distance }));
+  }
+
+  const results: Array<{ meta: OutcodeMetadata; distance: number; rank: number }> = [];
+
+  for (const { meta, distance } of baseList) {
+    const haystacks = [meta.outcode, meta.label, ...meta.areas].map((value) =>
+      value.toLowerCase(),
+    );
+    let bestIndex = Number.POSITIVE_INFINITY;
+    let matched = false;
+
+    for (const text of haystacks) {
+      const index = text.indexOf(cleanedQuery);
+      if (index !== -1) {
+        matched = true;
+        if (index < bestIndex) {
+          bestIndex = index;
+        }
+      }
+    }
+
+    if (!matched) continue;
+
+    results.push({ meta, distance, rank: bestIndex });
+  }
+
+  results.sort((a, b) => {
+    if (a.rank !== b.rank) {
+      return a.rank - b.rank;
+    }
+    if (a.meta.priority !== b.meta.priority) {
+      return a.meta.priority - b.meta.priority;
+    }
+    if (a.distance !== b.distance) {
+      return a.distance - b.distance;
+    }
+    return a.meta.outcode.localeCompare(b.meta.outcode);
+  });
+
+  return results.slice(0, limit).map(({ meta, distance }) => ({
+    ...meta,
+    distanceMiles: distance,
+  }));
+}
+
+export const outcodeData = OUTCODE_LIST.map((meta) => ({
+  ...meta,
+  distanceMiles: distanceFromBase(meta.outcode),
+}));
+
+export const surveyTypes: Array<{ id: SurveyType; label: string }> = Object.entries(
+  SURVEY_PRICING,
+).map(([id, config]) => ({
+  id: id as SurveyType,
+  label: config.label,
+}));
+
+export const extraServiceList = Object.entries(EXTRA_SERVICES).map(([id, config]) => ({
+  id: id as ExtraService,
+  ...config,
+}));

--- a/src/pages/local-surveys.astro
+++ b/src/pages/local-surveys.astro
@@ -1,4 +1,5 @@
 ---
+import AreaLinks from '../components/AreaLinks.tsx';
 import BaseLayout from '../layouts/BaseLayout.astro';
 
 const areas = [
@@ -274,6 +275,11 @@ const areas = [
           <a href={`#${area.id}`}>{area.navLabel}</a>
         ))}
       </nav>
+      <p><strong>Ready to get a tailored quote?</strong></p>
+      <AreaLinks
+        areas={areas.map((area) => area.navLabel)}
+        className="area-nav area-nav--quote"
+      />
     </div>
   </section>
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "astro/tsconfigs/strict",
   "compilerOptions": {
-    "baseUrl": "."
+    "baseUrl": ".",
+    "jsx": "react-jsx",
+    "jsxImportSource": "react"
   }
 }


### PR DESCRIPTION
## Summary
- implement a pricing engine with VAT handling, distance bands, and postcode metadata plus companion tests
- add area lookup data and new React components for quote calculator UI and area quote links
- enable the Astro React integration and surface the quote links on the local surveys page

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68cfd20f902483238dc53fc89de645da