### PR TITLE
Normalize full postcodes before area lookup

### DIFF
--- a/src/lib/areas.test.ts
+++ b/src/lib/areas.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { getAreasForOutcode } from './areas';
+
+describe('getAreasForOutcode', () => {
+  it('returns expected areas for CH5 outcode', () => {
+    const areas = getAreasForOutcode('CH5');
+    expect(areas.map((area) => area.id)).toEqual([
+      'connahs-quay',
+      'shotton',
+      'queensferry',
+      'hawarden',
+      'ewloe',
+      'deeside',
+    ]);
+  });
+
+  it('normalises full postcodes to match their outcodes', () => {
+    const fromOutcode = getAreasForOutcode('CH5');
+    const fromPostcode = getAreasForOutcode('CH5 4HS');
+
+    expect(fromPostcode.map((area) => area.id)).toEqual(fromOutcode.map((area) => area.id));
+  });
+});

--- a/src/lib/areas.ts
+++ b/src/lib/areas.ts
@@ -237,7 +237,11 @@ export const getAreasForOutcode = (outcode: string): AreaInfo[] => {
     return [];
   }
 
-  return OUTCODE_LOOKUP.get(normaliseOutcode(outcode)) ?? [];
+  const normalised = normaliseOutcode(outcode);
+  const match = normalised.match(/^([A-Z]{1,2}\d[A-Z\d]?)(\d[A-Z]{2})$/);
+  const outwardCode = match ? match[1] : normalised;
+
+  return OUTCODE_LOOKUP.get(outwardCode) ?? [];
 };
 
 export const getPrimaryOutcodeForArea = (areaId: AreaKey): string | undefined => {


### PR DESCRIPTION
## Summary
- normalise postcode queries by extracting the outward code before checking the outcode lookup
- add unit tests confirming CH5 outcode and CH5 4HS postcode resolve to the same service areas

## Testing
- npx vitest run src/lib/areas.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68cfe884f0a08323a7ac915f651eaaf3