### PR TITLE
Add survey quote calculator link to homepage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -132,6 +132,10 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           Serving Deeside, Chester, Flintshire, Wrexham &amp; the North West with
           trusted inspections &amp; advice
         </p>
+        <p class="hero-subtitle">
+          Prefer to explore guide pricing first?
+          <a class="inline-link" href="/quote.html">Try the Survey Quote Calculator →</a>
+        </p>
         <div class="center-cta">
           <a class="cta-button hero-contrast" href="/enquiry.html">
             Get a Free Quote


### PR DESCRIPTION
## Summary
- add a homepage prompt linking to the survey quote calculator so visitors can explore guide pricing

- [x] Tested locally (`npm run build`)
- [ ] Validated schema
- [ ] Lighthouse run
- [ ] Semrush item referenced

## Additional context
N/A

------
https://chatgpt.com/codex/tasks/task_b_68cff7106928832386b29dca3c76c5ad