### PR TITLE
Use sitemap integration in Astro config

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,17 +1,7 @@
 import { defineConfig } from 'astro/config';
-import mdx from '@astrojs/mdx';
+import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
   site: 'https://www.lembuildingsurveying.co.uk',
-  output: 'static',
-  integrations: [mdx()],
-  build: {
-    format: 'file'
-  },
-  vite: {
-    build: {
-      minify: 'terser',
-      cssMinify: 'lightningcss'
-    }
-  }
+  integrations: [sitemap()]
 });


### PR DESCRIPTION
## Summary
- replace the MDX integration with the sitemap integration in the Astro config
- keep the configured site URL while simplifying the config to the new template

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cff9ee861c8331a9da74ed4be5f7a0