### PR TITLE
Update enquiry workflow to send confirmed fee estimate

### DIFF
--- a/src/components/QuoteCalculator.tsx
+++ b/src/components/QuoteCalculator.tsx
@@ -235,7 +235,7 @@ const QuoteCalculator = (): JSX.Element => {
 
   const contactStatusMessage =
     submissionState === 'success'
-      ? 'Thanks! We will confirm your quote shortly.'
+      ? 'Thanks! We will confirm your fee shortly.'
       : submissionState === 'error'
       ? submissionError
       : null;
@@ -493,7 +493,7 @@ const QuoteCalculator = (): JSX.Element => {
           </fieldset>
 
           <fieldset className="lem-quote-calculator__fieldset">
-            <legend className="lem-quote-calculator__legend">Request your guide quote</legend>
+            <legend className="lem-quote-calculator__legend">Request your confirmed fee</legend>
 
             <div className="lem-quote-calculator__field">
               <label htmlFor="contact-name">Your name</label>
@@ -552,7 +552,7 @@ const QuoteCalculator = (): JSX.Element => {
 
             <div className="lem-quote-calculator__cta">
               <button type="submit" className="cta-button" disabled={submitting} aria-describedby={CONTACT_STATUS_ID}>
-                {submitting ? 'Sending…' : 'Email this guide quote'}
+                {submitting ? 'Sending…' : 'Send enquiry'}
               </button>
               <p className="lem-quote-calculator__hint" id={CONTACT_STATUS_ID} aria-live="polite">
                 {contactStatusMessage ?? ' '}
@@ -575,7 +575,7 @@ const QuoteCalculator = (): JSX.Element => {
           ) : null}
 
           <div>
-            <span className="lem-quote-calculator__label">Guide fee</span>
+            <span className="lem-quote-calculator__label">Estimated fee</span>
             <p className="lem-quote-calculator__figure">{formatCurrency(quote.total.gross)}</p>
             <span className="lem-quote-calculator__range">Typically {formatRange(quote.range)}</span>
             <p className="lem-quote-calculator__turnaround">{selectedSurvey.turnaround}</p>
@@ -615,7 +615,7 @@ const QuoteCalculator = (): JSX.Element => {
           </div>
 
           <p className="lem-quote-calculator__disclaimer">
-            Guide assumes {selectedComplexity.label.toLowerCase()} and typical access.
+            Estimate assumes {selectedComplexity.label.toLowerCase()} and typical access.
             {selectedDistanceBand
               ? ` Travel band: ${selectedDistanceBand.label}.`
               : ' Travel within our standard area.'}

--- a/src/pages/enquiry.astro
+++ b/src/pages/enquiry.astro
@@ -128,7 +128,23 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             return;
           }
 
+          const ENQUIRIES_EMAIL = "enquiries@lembuildingsurveying.co.uk";
           const propertyValueInput = form.querySelector("#property-value");
+          const surveyTypeSelect = form.querySelector("#survey-type");
+
+          const currencyFormatter = new Intl.NumberFormat("en-GB", {
+            style: "currency",
+            currency: "GBP",
+            maximumFractionDigits: 0,
+          });
+
+          const CONTACT_METHOD_LABELS = {
+            email: "Email",
+            "phone-call": "Phone call",
+            "text-message": "SMS / Text Message",
+            whatsapp: "WhatsApp",
+            "no-preference": "No preference",
+          };
 
           const normalisePropertyValue = () => {
             if (!propertyValueInput) {
@@ -157,6 +173,144 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             propertyValueInput.addEventListener("blur", normalisePropertyValue);
           }
 
+          const buildEstimatePayload = (fields) => {
+            const email =
+              typeof fields.email === "string" ? fields.email.trim() : "";
+            if (!email) {
+              return null;
+            }
+
+            const name =
+              typeof fields.name === "string" && fields.name.trim()
+                ? fields.name.trim()
+                : undefined;
+
+            let surveyLabel = "";
+            if (surveyTypeSelect instanceof HTMLSelectElement) {
+              const selectedOption =
+                surveyTypeSelect.options[surveyTypeSelect.selectedIndex];
+              if (selectedOption) {
+                surveyLabel = selectedOption.text.trim();
+              }
+            }
+
+            if (
+              !surveyLabel &&
+              typeof fields["survey-type"] === "string" &&
+              fields["survey-type"].trim()
+            ) {
+              surveyLabel = fields["survey-type"].trim();
+            }
+
+            const rawPropertyValue =
+              typeof fields["property-value"] === "string"
+                ? fields["property-value"].trim()
+                : "";
+            const cleanedPropertyValue = rawPropertyValue.replace(/[,£\s]+/g, "");
+            const propertyValueNumber = cleanedPropertyValue
+              ? Number.parseFloat(cleanedPropertyValue)
+              : Number.NaN;
+            const hasPropertyValue =
+              Number.isFinite(propertyValueNumber) && propertyValueNumber > 0;
+            const formattedPropertyValue = hasPropertyValue
+              ? currencyFormatter.format(propertyValueNumber)
+              : null;
+
+            let contactMethodLabel = "";
+            if (
+              typeof fields["contact-method"] === "string" &&
+              fields["contact-method"].trim()
+            ) {
+              const rawContactMethod = fields["contact-method"].trim();
+              contactMethodLabel =
+                CONTACT_METHOD_LABELS[rawContactMethod] || rawContactMethod;
+            }
+
+            const notes = [
+              "Fee to be confirmed after our review of your enquiry.",
+            ];
+
+            if (contactMethodLabel) {
+              notes.push(`Preferred contact method: ${contactMethodLabel}.`);
+            }
+
+            if (typeof fields.phone === "string" && fields.phone.trim()) {
+              notes.push(`Phone: ${fields.phone.trim()}`);
+            }
+
+            if (formattedPropertyValue) {
+              notes.push(`Estimated property value: ${formattedPropertyValue}.`);
+            }
+
+            if (typeof fields.details === "string" && fields.details.trim()) {
+              notes.push(
+                `Additional notes from client:\n${fields.details.trim()}`,
+              );
+            }
+
+            const lineItemDescription = `${
+              surveyLabel || "Survey"
+            } fee (to be confirmed)`;
+            const lineItem = formattedPropertyValue
+              ? {
+                  description: lineItemDescription,
+                  notes: `Based on an estimated property value of ${formattedPropertyValue}.`,
+                }
+              : { description: lineItemDescription };
+
+            const estimateNotes = notes.join("\n\n");
+
+            return {
+              to: email,
+              bcc: ENQUIRIES_EMAIL,
+              replyTo: ENQUIRIES_EMAIL,
+              subject: surveyLabel
+                ? `${surveyLabel} enquiry – fee to be confirmed`
+                : "Survey enquiry – fee to be confirmed",
+              estimate: {
+                clientName: name,
+                clientEmail: email,
+                surveyType: surveyLabel || undefined,
+                propertyAddress:
+                  typeof fields.address === "string" && fields.address.trim()
+                    ? fields.address.trim()
+                    : undefined,
+                lineItems: [lineItem],
+                notes: estimateNotes,
+                summary: "Fee to be confirmed after review.",
+                turnaround: "We will confirm your fixed fee shortly.",
+              },
+            };
+          };
+
+          const sendEstimateEmail = async (fields) => {
+            const payload = buildEstimatePayload(fields);
+            if (!payload) {
+              return;
+            }
+
+            const response = await fetch(
+              "/.netlify/functions/send-estimate-email",
+              {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(payload),
+              },
+            );
+
+            if (!response.ok) {
+              const errorPayload = await response.json().catch(() => null);
+              const message =
+                (errorPayload &&
+                  typeof errorPayload.error === "string" &&
+                  errorPayload.error) ||
+                "Failed to send estimate email.";
+              throw new Error(message);
+            }
+
+            return response.json().catch(() => null);
+          };
+
           form.addEventListener("submit", async (e) => {
             e.preventDefault();
             normalisePropertyValue();
@@ -171,15 +325,43 @@ import BaseLayout from '../layouts/BaseLayout.astro';
               data.set("property-value", propertyValueInput.value.trim());
             }
 
-            const resp = await fetch("https://formspree.io/f/xzzdqqqz", {
-              method: "POST",
-              body: data,
-              headers: { Accept: "application/json" },
+            const fields = {};
+            data.forEach((value, key) => {
+              if (typeof value === "string") {
+                fields[key] = value.trim();
+              } else {
+                fields[key] = value;
+              }
             });
 
-            if (resp.ok) {
-              /* fire Google-Ads conversion before leaving */
-              gtag("event", "conversion", { send_to: "AW-XXXXXXXXXX/AbCdEFgHiJk" });
+            let formspreeResponse;
+            try {
+              formspreeResponse = await fetch("https://formspree.io/f/xzzdqqqz", {
+                method: "POST",
+                body: data,
+                headers: { Accept: "application/json" },
+              });
+            } catch (error) {
+              alert("Sorry, something went wrong. Please email us directly.");
+              return;
+            }
+
+            if (formspreeResponse.ok) {
+              try {
+                await sendEstimateEmail(fields);
+              } catch (error) {
+                console.error("Unable to send estimate email", error);
+              }
+
+              if (
+                typeof window !== "undefined" &&
+                typeof window.gtag === "function"
+              ) {
+                window.gtag("event", "conversion", {
+                  send_to: "AW-XXXXXXXXXX/AbCdEFgHiJk",
+                });
+              }
+
               window.location = "/thank-you.html";
             } else {
               alert("Sorry, something went wrong. Please email us directly.");


### PR DESCRIPTION
## Summary

- [x] Tested locally
- [ ] Validated schema
- [ ] Lighthouse run
- [ ] Semrush item referenced

- Retitle the quote calculator legend, CTA text, and success message to emphasise requesting a confirmed fee.
- Update the calculator results panel copy to describe the output as an estimated fee instead of a guide.
- Extend the enquiries form script to trigger the Netlify estimate email with to-be-confirmed messaging while keeping the Formspree submission flow intact.

## Additional context

- Ran `npm test`.


------
https://chatgpt.com/codex/tasks/task_b_68d000560ee88323bb72f0a4c7e40de5