### PR TITLE
fix: hide fee breakdown on quote calculator

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -77,5 +77,115 @@ const { pageId = '' } = Astro.props;
     </div>
     <Footer />
     <script type="module" src={navScriptUrl} is:inline></script>
+    <script is:inline>
+      (() => {
+        const normalisedPath = window.location.pathname.replace(/\/+$/, "");
+        if (
+          normalisedPath !== "/quote-calculator" &&
+          normalisedPath !== "/quote-calculator.html"
+        ) {
+          return;
+        }
+
+        /**
+         * Finds the nearest removable ancestor for a breakdown fragment while
+         * avoiding removing the entire document body.
+         * @param {Element} element
+         */
+        const findContainer = (element) => {
+          const candidates = [
+            element.closest("details"),
+            element.closest("section"),
+            element.closest("article"),
+            element.closest("div"),
+          ];
+
+          for (const candidate of candidates) {
+            if (
+              candidate &&
+              candidate !== document.body &&
+              candidate !== document.documentElement
+            ) {
+              return candidate;
+            }
+          }
+
+          return element;
+        };
+
+        const selectors = [
+          '[data-component*="breakdown" i]',
+          '[data-role*="breakdown" i]',
+          '[data-testid*="breakdown" i]',
+          '[data-test*="breakdown" i]',
+          '[id*="breakdown" i]',
+          '[class*="breakdown" i]',
+        ];
+
+        const removeBreakdown = () => {
+          let removed = false;
+
+          selectors.forEach((selector) => {
+            document.querySelectorAll(selector).forEach((element) => {
+              if (!(element instanceof HTMLElement)) {
+                return;
+              }
+
+              const target = findContainer(element);
+              if (
+                target instanceof HTMLElement &&
+                target !== document.body &&
+                target !== document.documentElement
+              ) {
+                target.remove();
+                removed = true;
+              }
+            });
+          });
+
+          if (!removed) {
+            const fallback = Array.from(
+              document.querySelectorAll("section, article, div, details"),
+            ).find((node) => {
+              if (!(node instanceof HTMLElement)) {
+                return false;
+              }
+
+              const heading = node.querySelector(
+                "h2, h3, h4, summary, .section-title",
+              );
+              return heading
+                ? /breakdown/i.test(heading.textContent ?? "")
+                : false;
+            });
+
+            if (
+              fallback instanceof HTMLElement &&
+              fallback !== document.body &&
+              fallback !== document.documentElement
+            ) {
+              fallback.remove();
+            }
+          }
+        };
+
+        const observer = new MutationObserver(() => {
+          removeBreakdown();
+        });
+
+        const initialise = () => {
+          removeBreakdown();
+          observer.observe(document.body, { childList: true, subtree: true });
+        };
+
+        if (document.readyState === "loading") {
+          document.addEventListener("DOMContentLoaded", initialise, {
+            once: true,
+          });
+        } else {
+          initialise();
+        }
+      })();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add an inline script in the shared layout that watches for the quote-calculator route
- remove any fee-breakdown DOM fragment when the calculator page is loaded so the itemised costs stay hidden

## Testing
- npm run check
- npx vitest run --reporter=basic

------
https://chatgpt.com/codex/tasks/task_b_68d05472b6d88331acd06e353f0a7978