### PR TITLE
Adjust property complexity uplifts

### DIFF
--- a/public/lem-quote.css
+++ b/public/lem-quote.css
@@ -65,7 +65,8 @@
 }
 
 .lem-quote-calculator__field input,
-.lem-quote-calculator__field select {
+.lem-quote-calculator__field select,
+.lem-quote-calculator__field textarea {
   appearance: none;
   border-radius: 0.75rem;
   border: 1px solid var(--divider-grey, #dfe6f5);
@@ -77,7 +78,8 @@
 }
 
 .lem-quote-calculator__field input:focus,
-.lem-quote-calculator__field select:focus {
+.lem-quote-calculator__field select:focus,
+.lem-quote-calculator__field textarea:focus {
   outline: none;
   border-color: var(--accent-blue, #2563eb);
   box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
@@ -101,6 +103,21 @@
 
 .lem-quote-calculator__hint--error {
   color: var(--error-red, #b91c1c);
+}
+
+.lem-quote-calculator__option-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.65rem;
+}
+
+.lem-quote-calculator__option-list label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-weight: 600;
+  color: var(--text-main, #1f2937);
 }
 
 .lem-quote-calculator__result {

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -11,7 +11,13 @@ export type SurveyType =
   | 'epc'
   | 'measured';
 
-export type ComplexityType = 'standard' | 'extended' | 'period';
+export type ComplexityType =
+  | 'standard'
+  | 'interwar'
+  | 'extended'
+  | 'extended-and-converted'
+  | 'victorian'
+  | 'period';
 
 export type DistanceBandId =
   | 'within-10-miles'
@@ -195,14 +201,32 @@ export const COMPLEXITY_OPTIONS: readonly ComplexityOption[] = [
     helper: 'Typical brick or block construction without major alterations.',
   },
   {
+    id: 'interwar',
+    label: 'Interwar era (1919–1944)',
+    adjustment: 25,
+    helper: 'Homes from 1919–1944 that benefit from extra checks on cavities, insulation and services.',
+  },
+  {
     id: 'extended',
-    label: 'Extended / altered',
-    adjustment: 70,
-    helper: 'Includes loft conversions, sizeable extensions or multiple outbuildings.',
+    label: 'Extended or converted',
+    adjustment: 50,
+    helper: 'Includes a loft conversion or sizeable extension requiring additional inspection time.',
+  },
+  {
+    id: 'extended-and-converted',
+    label: 'Extended & converted',
+    adjustment: 75,
+    helper: 'Both an extension and a conversion or multiple major alterations needing further analysis.',
+  },
+  {
+    id: 'victorian',
+    label: 'Victorian / Edwardian',
+    adjustment: 50,
+    helper: 'Late 1800s or early 1900s homes with period detailing and known maintenance quirks.',
   },
   {
     id: 'period',
-    label: 'Period / non-standard',
+    label: 'Pre-1900 / non-standard',
     adjustment: 130,
     helper: 'Pre-1900 homes, listed buildings or properties with unusual materials.',
   },


### PR DESCRIPTION
## Summary
- refine pricing complexity categories to cover interwar, Victorian, and combined extension scenarios with updated uplift values
- derive the quote calculator's complexity selection from property age and extension detail combinations so the highest uplift applies automatically

## Testing
- npm run check
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68d0fdef68848331b2f514e82bfe335f