### PR TITLE
Handle extension surcharge validation

### DIFF
--- a/src/components/QuoteCalculator.tsx
+++ b/src/components/QuoteCalculator.tsx
@@ -110,7 +110,8 @@ const QuoteCalculator = (): JSX.Element => {
   const bedrooms = useMemo(() => parseBedroomsValue(bedroomsInput), [bedroomsInput]);
   const selectedDistanceBand = useMemo(() => getDistanceBandById(distanceBandId), [distanceBandId]);
   const { extended: hasExtended, converted: hasConverted } = extensionTypes;
-  const hasExtensionSelection = extensionStatus === 'yes' && (hasExtended || hasConverted);
+  const hasExtensionDetailSelection = hasExtended || hasConverted;
+  const requiresExtendedComplexity = extensionStatus === 'yes';
   const isPeriodProperty = propertyAge === 'victorian-edwardian' || propertyAge === 'pre-1900';
 
   const extensionSummary = useMemo(() => {
@@ -179,12 +180,12 @@ const QuoteCalculator = (): JSX.Element => {
     let nextComplexity: ComplexityType = 'standard';
     if (isPeriodProperty) {
       nextComplexity = 'period';
-    } else if (hasExtensionSelection) {
+    } else if (requiresExtendedComplexity) {
       nextComplexity = 'extended';
     }
 
     if (complexity !== nextComplexity) setComplexity(nextComplexity);
-  }, [complexity, hasExtensionSelection, isPeriodProperty]);
+  }, [complexity, isPeriodProperty, requiresExtendedComplexity]);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -336,6 +337,19 @@ const QuoteCalculator = (): JSX.Element => {
     const form = event.currentTarget;
     if (!form.checkValidity()) {
       form.reportValidity();
+      return;
+    }
+
+    if (extensionStatus === 'yes' && !hasExtensionDetailSelection) {
+      const firstDetailInput = form.querySelector<HTMLInputElement>('input[name="extension-detail-extended"]');
+      if (firstDetailInput) {
+        firstDetailInput.setCustomValidity('Select at least one extension detail.');
+        firstDetailInput.reportValidity();
+        firstDetailInput.setCustomValidity('');
+        firstDetailInput.focus();
+      }
+      setSubmissionState('error');
+      setSubmissionError('Select at least one extension detail so we can confirm the surcharge.');
       return;
     }
 

--- a/tests/quote-calculator.test.tsx
+++ b/tests/quote-calculator.test.tsx
@@ -1,0 +1,83 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import QuoteCalculator from '../src/components/QuoteCalculator';
+
+describe('QuoteCalculator extension handling', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root.render(<QuoteCalculator />);
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  test('applies extended complexity when extension status is yes without details', async () => {
+    const extensionSelect = container.querySelector<HTMLSelectElement>('#extension-status');
+    expect(extensionSelect).not.toBeNull();
+
+    const initialDisclaimer = container.querySelector<HTMLParagraphElement>(
+      '.lem-quote-calculator__disclaimer',
+    );
+    expect(initialDisclaimer?.textContent).toContain('standard construction');
+
+    await act(async () => {
+      extensionSelect!.value = 'yes';
+      extensionSelect!.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    const updatedDisclaimer = container.querySelector<HTMLParagraphElement>(
+      '.lem-quote-calculator__disclaimer',
+    );
+    expect(updatedDisclaimer?.textContent).toContain('extended / altered');
+  });
+
+  test('prevents submission when extension is yes without details', async () => {
+    const nameInput = container.querySelector<HTMLInputElement>('#contact-name');
+    const emailInput = container.querySelector<HTMLInputElement>('#contact-email');
+    const extensionSelect = container.querySelector<HTMLSelectElement>('#extension-status');
+    const form = container.querySelector<HTMLFormElement>('form');
+
+    expect(nameInput && emailInput && extensionSelect && form).not.toBeNull();
+
+    await act(async () => {
+      nameInput!.value = 'Test User';
+      nameInput!.dispatchEvent(new Event('input', { bubbles: true }));
+      emailInput!.value = 'test@example.com';
+      emailInput!.dispatchEvent(new Event('input', { bubbles: true }));
+      extensionSelect!.value = 'yes';
+      extensionSelect!.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    const originalFetch = globalThis.fetch;
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({}) } as unknown as Response);
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+
+    try {
+      await act(async () => {
+        const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
+        form!.dispatchEvent(submitEvent);
+      });
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,4 +1,13 @@
+import React from 'react';
+
 Object.defineProperty(document, 'readyState', {
   configurable: true,
-  value: 'complete'
+  value: 'complete',
 });
+
+(globalThis as typeof globalThis & {
+  React: typeof React;
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+}).React = React;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;


### PR DESCRIPTION
## Summary
- ensure properties marked as extended always use extended pricing and report a validation error when no detail checkboxes are ticked
- initialise the React test environment for jsdom and add coverage for the “yes without details” flow in the quote calculator

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d1197a33e483319648d96425ddc00e