### PR TITLE
Fix automatic complexity selection in quote calculator

### DIFF
--- a/src/components/QuoteCalculator.tsx
+++ b/src/components/QuoteCalculator.tsx
@@ -112,7 +112,6 @@ const QuoteCalculator = (): JSX.Element => {
   const { extended: hasExtended, converted: hasConverted } = extensionTypes;
   const hasExtensionDetailSelection = hasExtended || hasConverted;
   const requiresExtendedComplexity = extensionStatus === 'yes';
-  const isPeriodProperty = propertyAge === 'victorian-edwardian' || propertyAge === 'pre-1900';
   const hasExtensionDetail = extensionStatus === 'yes' && (hasExtended || hasConverted);
   const hasBothExtensionDetails = extensionStatus === 'yes' && hasExtended && hasConverted;
 
@@ -179,7 +178,7 @@ const QuoteCalculator = (): JSX.Element => {
   }, [extensionStatus, hasConverted, hasExtended]);
 
   useEffect(() => {
-    const candidateComplexities: ComplexityType[] = [];
+    const candidateComplexities: ComplexityType[] = ['standard'];
 
     if (propertyAge === 'pre-1900') {
       candidateComplexities.push('period');
@@ -191,19 +190,11 @@ const QuoteCalculator = (): JSX.Element => {
 
     if (hasBothExtensionDetails) {
       candidateComplexities.push('extended-and-converted');
-    } else if (hasExtensionDetail) {
+    } else if (hasExtensionDetail || requiresExtendedComplexity) {
       candidateComplexities.push('extended');
     }
 
-    let nextComplexity: ComplexityType = 'standard';
-    if (isPeriodProperty) {
-      nextComplexity = 'period';
-    } else if (requiresExtendedComplexity) {
-      nextComplexity = 'extended';
-    }
-
-    if (complexity !== nextComplexity) setComplexity(nextComplexity);
-  }, [complexity, isPeriodProperty, requiresExtendedComplexity]);
+    let nextComplexity = candidateComplexities[0];
     for (const candidate of candidateComplexities) {
       const bestOption = getComplexityById(nextComplexity);
       const candidateOption = getComplexityById(candidate);
@@ -218,6 +209,7 @@ const QuoteCalculator = (): JSX.Element => {
     hasBothExtensionDetails,
     hasExtensionDetail,
     propertyAge,
+    requiresExtendedComplexity,
   ]);
 
   useEffect(() => {

--- a/tests/quote-calculator.test.tsx
+++ b/tests/quote-calculator.test.tsx
@@ -42,7 +42,7 @@ describe('QuoteCalculator extension handling', () => {
     const updatedDisclaimer = container.querySelector<HTMLParagraphElement>(
       '.lem-quote-calculator__disclaimer',
     );
-    expect(updatedDisclaimer?.textContent).toContain('extended / altered');
+    expect(updatedDisclaimer?.textContent).toContain('extended or converted');
   });
 
   test('prevents submission when extension is yes without details', async () => {


### PR DESCRIPTION
## Summary
- ensure the quote calculator picks the highest relevant complexity based on property age and extension details
- fall back to extended complexity when extension status is yes without detail selections and keep a default baseline option
- update the unit test to assert the revised disclaimer copy for the extended complexity scenario

## Testing
- npm run build
- CI=1 npm run test

------
https://chatgpt.com/codex/tasks/task_b_68d11e88a904833194cc1a9b773365fd