### PR TITLE
Type quote input with property attributes

### DIFF
--- a/src/components/QuoteCalculator.tsx
+++ b/src/components/QuoteCalculator.tsx
@@ -16,6 +16,7 @@ import {
   type ExtensionStatusId,
   type PropertyAgeId,
   type PropertyTypeId,
+  type QuoteInput,
   type QuoteRange,
   type SurveyType,
 } from '../lib/pricing';
@@ -127,19 +128,18 @@ const QuoteCalculator = (): JSX.Element => {
     return 'yes (details not specified)';
   }, [extensionStatus, hasConverted, hasExtended]);
 
-  const quote = useMemo(
-    () =>
-      calculateQuote({
-        surveyType,
-        propertyValue,
-        bedrooms,
-        complexity,
-        distanceBandId,
-        propertyType,
-        propertyAge,
-        extensionStatus,
-        extensionDetails: { extended: hasExtended, converted: hasConverted },
-      }),
+  const quoteInput = useMemo<QuoteInput>(
+    () => ({
+      surveyType,
+      propertyValue,
+      bedrooms,
+      complexity,
+      distanceBandId,
+      propertyType,
+      propertyAge,
+      extensionStatus,
+      extensionDetails: { extended: hasExtended, converted: hasConverted },
+    }),
     [
       surveyType,
       propertyValue,
@@ -153,6 +153,8 @@ const QuoteCalculator = (): JSX.Element => {
       hasConverted,
     ],
   );
+
+  const quote = useMemo(() => calculateQuote(quoteInput), [quoteInput]);
 
   const previousFormValuesRef = useRef({
     surveyType,


### PR DESCRIPTION
## Summary
- build the quote input object with the property type, age and extension details before calling `calculateQuote`
- import the shared `QuoteInput` type so TypeScript recognises the expanded payload

## Testing
- npm run test -- --reporter=basic


------
https://chatgpt.com/codex/tasks/task_b_68d15b2405c4833185e03f5da1adad66