### PR TITLE
Update VAT messaging across site

### DIFF
--- a/src/pages/independent-damp-survey-vs-contractor.astro
+++ b/src/pages/independent-damp-survey-vs-contractor.astro
@@ -73,7 +73,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
             "name": "How much does an independent damp survey cost?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "Our independent damp and mould surveys typically start from £275+VAT locally. Pricing depends on property size, scope and whether lab testing or follow-up monitoring is required."
+              "text": "Our independent damp and mould surveys typically start from £275 with no VAT to add locally. Pricing depends on property size, scope and whether lab testing or follow-up monitoring is required."
             }
           },
           {
@@ -244,7 +244,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
       </p>
       <ul>
         <li>
-          <strong>Local surveys from £275+VAT:</strong> Pricing depends on property
+          <strong>Local surveys from £275 with no VAT to add:</strong> Pricing depends on property
           size, number of rooms assessed and travel distance.
         </li>
         <li>

--- a/src/pages/quote.astro
+++ b/src/pages/quote.astro
@@ -84,7 +84,7 @@ import QuoteCalculator from '../components/QuoteCalculator';
         </p>
         <ul>
           <li>Guide pricing covers RICS Level&nbsp;1, 2 &amp; 3 surveys plus damp, ventilation, EPC and measured surveys.</li>
-          <li>All figures include VAT and reflect the turnaround times delivered by our Deeside-based surveyor.</li>
+          <li>All figures are net fees with no VAT to add and reflect the turnaround times delivered by our Deeside-based surveyor.</li>
           <li>Planning a portfolio or combination of services? Submit the enquiry form for a tailored proposal within the hour.</li>
         </ul>
       </div>


### PR DESCRIPTION
## Summary
- update the quote page intro bullet so guide fees are described as net with no VAT to add
- revise damp survey copy (including FAQ JSON-LD) to remove +VAT wording and align with the new VAT policy
- confirm no other +VAT references remain in the pages directory

## Testing
- `npm run test` *(fails: existing vitest expectations for VAT maths no longer match the 0% VAT rate, and npm run build invoked by link-check fails because cssnano is unavailable)*

------
https://chatgpt.com/codex/tasks/task_b_68d17b6ee9348323b254db79800d92cd