### PR TITLE
Add hero CTA links below quote forms

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -90,6 +90,11 @@ const seo = {
             nearby
           </li>
         </ul>
+        <div class="center-cta">
+          <a class="cta-button hero-contrast" href="/quote">
+            Get Instant Estimate
+          </a>
+        </div>
       </form>
     </div>
   </section>

--- a/src/pages/rics-home-surveys.astro
+++ b/src/pages/rics-home-surveys.astro
@@ -146,6 +146,11 @@ const { Content } = await entry.render();
                 &amp; nearby
               </li>
             </ul>
+            <div class="center-cta">
+              <a class="cta-button hero-contrast" href="/quote">
+                Get Instant Estimate
+              </a>
+            </div>
           </form>
         </div>
       </section><section class="guide-callout">


### PR DESCRIPTION
## Summary
- add a centered "Get Instant Estimate" call-to-action immediately under the home page hero form
- repeat the same CTA under the RICS home surveys hero form to keep messaging consistent

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d19a1b2d188323bb06d88d936cd977