### PR TITLE
Update header nav estimate link

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -22,7 +22,7 @@ const primaryLinks: NavLink[] = [
 const secondaryLinks: NavLink[] = [
   { href: '/services', label: 'Services' },
   { href: '/local-surveys', label: 'Areas We Cover' },
-  { href: '/comparison', label: 'Pricing' },
+  { href: '/quote', label: 'Instant estimate' },
   { href: '/testimonials', label: 'Testimonials' },
   { href: '/contact', label: 'Contact' },
   { href: '/enquiry', label: 'Get a Quote', isCta: true },


### PR DESCRIPTION
## Summary
- update the header secondary navigation entry to point to the quote page with the "Instant estimate" label

## Testing
- npm test *(fails: existing src/pricing.test.ts quote engine assertions expect different bedroom and surcharge totals)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d19e156d208323bb5b82936e7a2519