### PR TITLE
Refactor home page layout to use ServiceContent

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import ServiceContent from '../components/ServiceContent.astro';
 import { areaSelectorOptions } from '../data/areas';
 import HomeInstantEstimate from '../components/HomeInstantEstimate';
 
@@ -10,49 +11,71 @@ const seo = {
   canonicalPath: '/',
   image: 'https://www.lembuildingsurveying.co.uk/logo-sticker.png',
 };
----
 
+const serviceContentEntry: any = {
+  id: 'pages/index',
+};
+---
 <BaseLayout seo={seo}>
   <Fragment slot="head">
+    <link rel="stylesheet" href='/calculator.css' />
     <link rel="stylesheet" href="/lem-quote.css" />
   </Fragment>
-  <section class="section hero hero-quote">
-    <div class="container hero-container">
-      <div class="review-badge">
-        <span class="stars">★★★★★</span>
-        <span class="rating-text">Rated 5 on Google &amp; Direct Reviews</span>
-      </div>
-      <h1>Independent Building Surveyor for Deeside, Chester &amp; Beyond</h1>
-      <p>
-        Make confident property decisions with a qualified surveyor’s report —
-        turnaround in as little as 5–7&nbsp;days. Get your tailored quote now and
-        secure your survey date.
-      </p>
-      <form
-        action="https://formspree.io/f/xzzdqqqz"
-        class="quote-form"
-        method="POST"
-      >
-        <input
-          name="_next"
-          type="hidden"
-          value="https://www.lembuildingsurveying.co.uk/thank-you"
-        />
-        <div class="form-grid">
-          <HomeInstantEstimate client:load />
-          <label class="field">Your Name
-            <input autocomplete="name" name="name" placeholder="e.g. Jane Smith" required type="text" />
-          </label>
-          <label class="field">Email
-            <input autocomplete="email" name="email" placeholder="e.g. jane@example.com" required type="email" />
-          </label>
-          <label class="field">Contact Number
-            <input autocomplete="tel" inputmode="tel" name="contact" placeholder="e.g. 01234 567890" required type="tel" />
-          </label>
-          <label class="field">Postcode
-            <input autocomplete="postal-code" name="postcode" placeholder="e.g. CH1 2AB" required type="text" />
-          </label>
-          <label class="field">Survey Type
+
+  <ServiceContent entry={serviceContentEntry}>
+    <section class="hero hero-plain hero-plain--survey">
+      <div class="hero-container legacy-container">
+        <div class="review-badge">
+          <span class="stars">★★★★★</span>
+          <span class="rating-text">Rated 5 on Google &amp; Direct Reviews</span>
+        </div>
+        <h1>Independent Building Surveyor for Deeside, Chester &amp; Beyond</h1>
+        <p>
+          Make confident property decisions with a qualified surveyor’s report —
+          turnaround in as little as 5–7&nbsp;days. Get your tailored quote now and
+          secure your survey date.
+        </p>
+        <form
+          action="https://formspree.io/f/xzzdqqqz"
+          class="quote-form"
+          method="POST"
+        >
+          <input
+            name="_next"
+            type="hidden"
+            value="https://www.lembuildingsurveying.co.uk/thank-you"
+          />
+          <div class="form-grid">
+            <HomeInstantEstimate client:load />
+            <input
+              autocomplete="name"
+              name="name"
+              placeholder="Your Name"
+              required
+              type="text"
+            />
+            <input
+              autocomplete="email"
+              name="email"
+              placeholder="Your Email"
+              required
+              type="email"
+            />
+            <input
+              autocomplete="tel"
+              inputmode="tel"
+              name="contact"
+              placeholder="Contact Number"
+              required
+              type="tel"
+            />
+            <input
+              autocomplete="postal-code"
+              name="postcode"
+              placeholder="Postcode"
+              required
+              type="text"
+            />
             <select name="survey-type" required>
               <option value="">Select a survey type</option>
               <option value="level-1">Level 1 — Condition Report</option>
@@ -60,55 +83,58 @@ const seo = {
               <option value="level-3">Level 3 — Building Survey</option>
               <option value="unsure">Unsure</option>
             </select>
-          </label>
-          <label class="field">No. of Bedrooms
-            <input inputmode="numeric" min="0" name="bedrooms" placeholder="e.g. 3" required step="1" type="number" />
-          </label>
-          <label class="field">Estimated Property Value (£)
             <input
-              inputmode="decimal"
+              inputmode="numeric"
+              min="0"
+              name="bedrooms"
+              placeholder="No. of Bedrooms"
+              required
+              step="1"
+              type="number"
+            />
+            <input
+              aria-label="Estimated Property Value (£)"
               autocomplete="transaction-amount"
+              inputmode="decimal"
               min="0.01"
               name="property-value"
-              placeholder="e.g. 250000"
+              placeholder="Estimated Property Value (£)"
               required
               step="0.01"
               type="number"
             />
-          </label>
-          <div class="field full">
-            <button class="cta-button hero-contrast" type="submit">
-              Get My Survey Quote in 60 Minutes
-            </button>
+            <div class="field full">
+              <button class="cta-button hero-contrast" type="submit">
+                Get My Survey Quote in 60 Minutes
+              </button>
+            </div>
           </div>
-        </div>
-        <div class="quote-form__footer">
-          <ul class="quote-benefits">
-            <li>
-              <strong>Fast, no-obligation quote</strong> direct from a surveyor
-            </li>
-            <li><strong>Out-of-hours responses</strong> whenever possible</li>
-            <li>
-              100% privacy — your details are <strong>never shared</strong>
-            </li>
-            <li>
-              Serving Connah’s Quay, Deeside, Chester, Mold, Buckley, Hawarden
-              &amp; nearby
-            </li>
-          </ul>
-          <div class="center-cta center-cta--full">
-            <a class="cta-button hero-contrast" href="/quote">
-              Get Instant Estimate
-            </a>
+          <div class="quote-form__footer">
+            <ul class="quote-benefits">
+              <li>
+                <strong>Fast, no-obligation quote</strong> direct from a surveyor
+              </li>
+              <li><strong>Out-of-hours responses</strong> whenever possible</li>
+              <li>
+                100% privacy — your details are <strong>never shared</strong>
+              </li>
+              <li>
+                Serving Connah’s Quay, Deeside, Chester, Mold, Buckley,
+                Hawarden &amp; nearby
+              </li>
+            </ul>
+            <div class="center-cta center-cta--full">
+              <a class="cta-button hero-contrast" href="/quote">
+                Get Instant Estimate
+              </a>
+            </div>
           </div>
-        </div>
-      </form>
-    </div>
-  </section>
+        </form>
+      </div>
+    </section>
 
-  <main>
-    <section aria-labelledby="hero-title" class="section hero hero--intro">
-      <div class="container hero-intro">
+    <section aria-labelledby="hero-title" class="hero hero--intro">
+      <div class="hero-intro">
         <h2 id="hero-title">Independent Property Surveyor</h2>
         <p class="hero-subtitle">
           Serving Deeside, Chester, Flintshire, Wrexham &amp; the North West with
@@ -122,270 +148,248 @@ const seo = {
       </div>
     </section>
 
-    <section
-      aria-labelledby="independent-title"
-      class="section section--alt home-intro"
-    >
-      <div class="container">
-        <h2 class="section-title section-title--blue" id="independent-title">
-          Independent Building &amp; Measured Surveys
-        </h2>
-        <p>
-          LEM Building Surveying is an <strong>independent building surveyor</strong>
-          supporting homeowners, landlords and investors across Flintshire,
-          Chester and the wider North West. From detailed Level 3 building
-          surveys to impartial damp investigations, every inspection is completed
-          by a qualified AssocRICS surveyor so you can make an informed decision
-          with confidence.
-        </p>
-        <p>
-          We frequently assist clients searching for
-          <a href="/local-surveys">surveyors in Flintshire</a>, a trusted
-          <a href="/deeside-damp-surveys">building surveyor in Deeside</a>, or an
-          <a href="/cheshire-damp-surveys">independent building surveyor in the North West</a>.
-          Our measured building survey service also travels further afield for
-          specialist projects, supporting developments in locations such as
-          Moorside, Bredbury, Wardle and even Hayling Island when detailed
-          measured data is required.
-        </p>
-        <p>
-          Need advice fast? Explore our resources on
-          <a href="/level-1-or-level-2">survey levels</a>,
-          <a href="/level-3">Level 3 building surveys</a>, or our guide to
-          <a href="/independent-damp-survey-vs-contractor">independent damp surveys</a>,
-          and visit our <a href="/blog-index">blog for property survey advice</a> before
-          booking. Every report is tailored to the property type so you receive
-          actionable insight rather than template commentary.
-        </p>
+    <section aria-labelledby="independent-title" class="home-intro">
+      <h2 class="section-title section-title--blue" id="independent-title">
+        Independent Building &amp; Measured Surveys
+      </h2>
+      <p>
+        LEM Building Surveying is an <strong>independent building surveyor</strong>
+        supporting homeowners, landlords and investors across Flintshire,
+        Chester and the wider North West. From detailed Level 3 building
+        surveys to impartial damp investigations, every inspection is completed
+        by a qualified AssocRICS surveyor so you can make an informed decision
+        with confidence.
+      </p>
+      <p>
+        We frequently assist clients searching for
+        <a href="/local-surveys">surveyors in Flintshire</a>, a trusted
+        <a href="/deeside-damp-surveys">building surveyor in Deeside</a>, or an
+        <a href="/cheshire-damp-surveys">independent building surveyor in the North West</a>.
+        Our measured building survey service also travels further afield for
+        specialist projects, supporting developments in locations such as
+        Moorside, Bredbury, Wardle and even Hayling Island when detailed
+        measured data is required.
+      </p>
+      <p>
+        Need advice fast? Explore our resources on
+        <a href="/level-1-or-level-2">survey levels</a>,
+        <a href="/level-3">Level 3 building surveys</a>, or our guide to
+        <a href="/independent-damp-survey-vs-contractor">independent damp surveys</a>,
+        and visit our <a href="/blog-index">blog for property survey advice</a> before
+        booking. Every report is tailored to the property type so you receive
+        actionable insight rather than template commentary.
+      </p>
+    </section>
+
+    <section aria-labelledby="services-title" class="home-services">
+      <h2 class="section-title section-title--blue" id="services-title">
+        Our Services
+      </h2>
+      <div class="cards">
+        <article class="card service-card">
+          <h3>RICS Home Surveys</h3>
+          <p>
+            Level&nbsp;1, 2 &amp; 3 reports for buyers, landlords and
+            professionals.
+          </p>
+          <a class="inline-link" href="/rics-home-surveys">
+            Explore RICS Surveys →
+          </a>
+        </article>
+        <article class="card service-card">
+          <h3>Damp &amp; Mould Reports</h3>
+          <p>Assessments for condensation, damp, and disrepair issues.</p>
+          <a class="inline-link" href="/damp-mould-surveys">
+            View Damp Reports →
+          </a>
+        </article>
+        <article class="card service-card">
+          <h3>Damp &amp; Timber Surveys</h3>
+          <p>For lenders, warranties, or timber decay concerns.</p>
+          <a class="inline-link" href="/damp-timber-surveys">Learn about Damp &amp; Timber Surveys →</a>
+        </article>
+        <article class="card service-card">
+          <h3>Measured Surveys &amp; Floorplans</h3>
+          <p>Scaled plans and elevations for design or records.</p>
+          <a class="inline-link" href="/measured-surveys">
+            See Measured Surveys →
+          </a>
+        </article>
+        <article class="card service-card">
+          <h3>EPCs with Floorplans</h3>
+          <p>Certificates &amp; floorplans for lettings, sales &amp; marketing.</p>
+          <a class="inline-link" href="/epc-with-floorplans">
+            EPC Options →
+          </a>
+        </article>
+        <article class="card service-card">
+          <h3>Ventilation Testing</h3>
+          <p>Anemometer airflow assessments for domestic properties.</p>
+          <a class="inline-link" href="/ventilation-assessments">
+            Book Ventilation →
+          </a>
+        </article>
+      </div>
+      <div class="center-cta">
+        <a class="cta-button" href="/services">Browse All Services</a>
       </div>
     </section>
 
-    <section
-      aria-labelledby="services-title"
-      class="section section--alt home-services"
-    >
-      <div class="container">
-        <h2 class="section-title section-title--blue" id="services-title">
-          Our Services
-        </h2>
-        <div class="cards">
-          <article class="card service-card">
-            <h3>RICS Home Surveys</h3>
-            <p>
-              Level&nbsp;1, 2 &amp; 3 reports for buyers, landlords and
-              professionals.
-            </p>
-            <a class="inline-link" href="/rics-home-surveys">
-              Explore RICS Surveys →
+    <section aria-labelledby="insights-title" class="resource-highlights">
+      <h2 class="section-title section-title--blue" id="insights-title">
+        Latest Guides &amp; Advice
+      </h2>
+      <div class="cards guide-cards">
+        <article class="card guide-card">
+          <h3>
+            <a href="/level-2-vs-level-3">Level 2 vs Level 3 Survey</a>
+          </h3>
+          <p>
+            See which RICS report fits your property, renovation plans and
+            risk profile.
+          </p>
+        </article>
+        <article class="card guide-card">
+          <h3>
+            <a href="/independent-damp-survey-vs-contractor">
+              Independent Damp Survey vs Contractor
             </a>
-          </article>
-          <article class="card service-card">
-            <h3>Damp &amp; Mould Reports</h3>
-            <p>Assessments for condensation, damp, and disrepair issues.</p>
-            <a class="inline-link" href="/damp-mould-surveys">
-              View Damp Reports →
-            </a>
-          </article>
-          <article class="card service-card">
-            <h3>Damp &amp; Timber Surveys</h3>
-            <p>For lenders, warranties, or timber decay concerns.</p>
-            <a class="inline-link" href="/damp-timber-surveys">Learn about Damp &amp; Timber Surveys →</a>
-          </article>
-          <article class="card service-card">
-            <h3>Measured Surveys &amp; Floorplans</h3>
-            <p>Scaled plans and elevations for design or records.</p>
-            <a class="inline-link" href="/measured-surveys">
-              See Measured Surveys →
-            </a>
-          </article>
-          <article class="card service-card">
-            <h3>EPCs with Floorplans</h3>
-            <p>Certificates &amp; floorplans for lettings, sales &amp; marketing.</p>
-            <a class="inline-link" href="/epc-with-floorplans">
-              EPC Options →
-            </a>
-          </article>
-          <article class="card service-card">
-            <h3>Ventilation Testing</h3>
-            <p>Anemometer airflow assessments for domestic properties.</p>
-            <a class="inline-link" href="/ventilation-assessments">
-              Book Ventilation →
-            </a>
-          </article>
-        </div>
-        <div class="center-cta">
-          <a class="cta-button" href="/services">Browse All Services</a>
-        </div>
+          </h3>
+          <p>
+            Understand the benefit of impartial diagnosis before agreeing to
+            remedial works.
+          </p>
+        </article>
+        <article class="card guide-card">
+          <h3><a href="/level-1-or-level-2">Level 1 or Level 2?</a></h3>
+          <p>Compare lighter-touch surveys for newer, conventional homes.</p>
+        </article>
+      </div>
+      <div class="center-cta">
+        <a class="cta-button" href="/blog-index">Explore All Articles</a>
       </div>
     </section>
 
-    <section aria-labelledby="insights-title" class="section resource-highlights">
-      <div class="container">
-        <h2 class="section-title section-title--blue" id="insights-title">
-          Latest Guides &amp; Advice
-        </h2>
-        <div class="cards guide-cards">
-          <article class="card guide-card">
-            <h3>
-              <a href="/level-2-vs-level-3">Level 2 vs Level 3 Survey</a>
-            </h3>
-            <p>
-              See which RICS report fits your property, renovation plans and
-              risk profile.
-            </p>
-          </article>
-          <article class="card guide-card">
-            <h3>
-              <a href="/independent-damp-survey-vs-contractor">
-                Independent Damp Survey vs Contractor
-              </a>
-            </h3>
-            <p>
-              Understand the benefit of impartial diagnosis before agreeing to
-              remedial works.
-            </p>
-          </article>
-          <article class="card guide-card">
-            <h3><a href="/level-1-or-level-2">Level 1 or Level 2?</a></h3>
-            <p>Compare lighter-touch surveys for newer, conventional homes.</p>
-          </article>
-        </div>
-        <div class="center-cta">
-          <a class="cta-button" href="/blog-index">Explore All Articles</a>
-        </div>
+    <section aria-labelledby="why-title" class="why-choose-us">
+      <h2 class="section-title section-title--blue" id="why-title">
+        Why Choose LEM Building Surveying?
+      </h2>
+      <ul class="why-choose-list">
+        <li>
+          <strong>Independent &amp; Local:</strong> Honest expert advice, no sales
+          pitch.
+        </li>
+        <li>
+          <strong>RICS Aligned:</strong> Surveys follow RICS best practice.
+        </li>
+        <li>
+          <strong>Clear Reporting:</strong> Structured, easy-to-action reports.
+        </li>
+        <li>
+          <strong>Fast Turnaround:</strong> Reports delivered within 2–5
+          working days.
+        </li>
+      </ul>
+      <div class="center-cta">
+        <a class="cta-button" href="/about">About the Surveyor</a>
       </div>
     </section>
 
-    <section aria-labelledby="why-title" class="section section--alt why-choose-us">
-      <div class="container">
-        <h2 class="section-title section-title--blue" id="why-title">
-          Why Choose LEM Building Surveying?
-        </h2>
-        <ul class="why-choose-list">
+    <section class="testimonials" id="testimonials">
+      <h2 class="section-title">Client Testimonials</h2>
+      <div class="ti-widget ti-goog"></div>
+    </section>
+
+    <section class="quick-nav">
+      <div class="jump-to">
+        <p><strong>Jump to:</strong></p>
+        <ul class="toc-list">
+          <li><a href="#services-title">Our Services</a></li>
+          <li><a href="#insights-title">Guides &amp; Advice</a></li>
+          <li><a href="#why-title">Why Choose Us</a></li>
+          <li><a href="#testimonials">Testimonials</a></li>
+          <li><a href="#areas-title">Areas We Cover</a></li>
+          <li><a href="#cta-title">Get a Quote</a></li>
+        </ul>
+      </div>
+    </section>
+
+    <section aria-labelledby="areas-title" class="home-areas improved-areas">
+      <h2 class="section-title section-title--blue" id="areas-title">
+        Areas We Cover
+      </h2>
+      <div class="dropdown-card">
+        <label class="dropdown-label" for="areaDropdown">
+          Jump to an area:
+        </label>
+        <div class="custom-select">
+          <select id="areaDropdown" onchange="handleAreaSelect(this)">
+            <option value="">Select an area…</option>
+            {areaSelectorOptions.map((area) => (
+              <option value={area.permalink}>{area.name}</option>
+            ))}
+          </select>
+          <span class="chevron">⌄</span>
+        </div>
+      </div>
+      <div class="area-links">
+        <p>
+          Prefer quick links? Explore our dedicated pages for popular
+          locations:
+        </p>
+        <ul>
           <li>
-            <strong>Independent &amp; Local:</strong> Honest expert advice, no sales
-            pitch.
+            <a href="/flintshire-damp-surveys">AssocRICS surveyor in Flintshire</a>
+            providing structural surveys and RICS Level 3 reports.
           </li>
           <li>
-            <strong>RICS Aligned:</strong> Surveys follow RICS best practice.
+            <a href="/mold-damp-surveys">Right of light surveys in Mold</a> alongside
+            homebuyer and building survey options.
           </li>
           <li>
-            <strong>Clear Reporting:</strong> Structured, easy-to-action reports.
+            <a href="/broughton-damp-surveys">Building surveys in Broughton</a>
+            plus residential surveyors for nearby Saltney.
           </li>
           <li>
-            <strong>Fast Turnaround:</strong> Reports delivered within 2–5
-            working days.
+            <a href="/buckley-damp-surveys">Building surveys in Buckley</a> covering
+            neighbouring villages such as Cholmondeley and Mynydd Isa.
+          </li>
+          <li>
+            <a href="/deeside-damp-surveys">Building surveyors near you in Deeside</a>
+            for Level 1, 2 and 3 inspections.
+          </li>
+          <li>
+            <a href="/chester-damp-surveys">Home buyer surveys in Chester</a> and the
+            surrounding suburbs including Hoole and Churton.
+          </li>
+          <li>
+            <a href="/cheshire-damp-surveys">Home condition reports across Cheshire</a>
+            from Helsby to Warmingham.
           </li>
         </ul>
-        <div class="center-cta">
-          <a class="cta-button" href="/about">About the Surveyor</a>
-        </div>
       </div>
     </section>
 
-    <section class="section testimonials" id="testimonials">
-      <div class="container">
-        <h2 class="section-title">Client Testimonials</h2>
-        <div class="ti-widget ti-goog"></div>
+    <section aria-labelledby="cta-title" class="home-get-started">
+      <h2 class="section-title section-title--blue" id="cta-title">
+        Get a Quote or Ask a Question
+      </h2>
+      <p>
+        We’re happy to help whether you’re ready to book or just comparing
+        options.
+      </p>
+      <div class="center-cta">
+        <a class="cta-button" href="/enquiry">Get My Quote</a>
       </div>
     </section>
 
-    <section class="section section--alt quick-nav-section">
-      <div class="container">
-        <nav aria-label="Page contents" class="quick-nav jump-to">
-          <p><strong>Jump to:</strong></p>
-          <ul class="toc-list">
-            <li><a href="#services-title">Our Services</a></li>
-            <li><a href="#insights-title">Guides &amp; Advice</a></li>
-            <li><a href="#why-title">Why Choose Us</a></li>
-            <li><a href="#testimonials">Testimonials</a></li>
-            <li><a href="#areas-title">Areas We Cover</a></li>
-            <li><a href="#cta-title">Get a Quote</a></li>
-          </ul>
-        </nav>
-      </div>
-    </section>
-
-    <section aria-labelledby="areas-title" class="section improved-areas">
-      <div class="container">
-        <h2 class="section-title section-title--blue" id="areas-title">
-          Areas We Cover
-        </h2>
-        <div class="dropdown-card">
-          <label class="dropdown-label" for="areaDropdown">
-            Jump to an area:
-          </label>
-          <div class="custom-select">
-            <select id="areaDropdown" onchange="handleAreaSelect(this)">
-              <option value="">Select an area…</option>
-              {areaSelectorOptions.map((area) => (
-                <option value={area.permalink}>{area.name}</option>
-              ))}
-            </select>
-            <span class="chevron">⌄</span>
-          </div>
-        </div>
-        <div class="area-links">
-          <p>
-            Prefer quick links? Explore our dedicated pages for popular
-            locations:
-          </p>
-          <ul>
-            <li>
-              <a href="/flintshire-damp-surveys">AssocRICS surveyor in Flintshire</a>
-              providing structural surveys and RICS Level 3 reports.
-            </li>
-            <li>
-              <a href="/mold-damp-surveys">Right of light surveys in Mold</a> alongside
-              homebuyer and building survey options.
-            </li>
-            <li>
-              <a href="/broughton-damp-surveys">Building surveys in Broughton</a>
-              plus residential surveyors for nearby Saltney.
-            </li>
-            <li>
-              <a href="/buckley-damp-surveys">Building surveys in Buckley</a> covering
-              neighbouring villages such as Cholmondeley and Mynydd Isa.
-            </li>
-            <li>
-              <a href="/deeside-damp-surveys">Building surveyors near you in Deeside</a>
-              for Level 1, 2 and 3 inspections.
-            </li>
-            <li>
-              <a href="/chester-damp-surveys">Home buyer surveys in Chester</a> and the
-              surrounding suburbs including Hoole and Churton.
-            </li>
-            <li>
-              <a href="/cheshire-damp-surveys">Home condition reports across Cheshire</a>
-              from Helsby to Warmingham.
-            </li>
-          </ul>
-        </div>
-      </div>
-    </section>
-
-    <section aria-labelledby="cta-title" class="section section--alt home-get-started">
-      <div class="container">
-        <h2 class="section-title section-title--blue" id="cta-title">
-          Get a Quote or Ask a Question
-        </h2>
-        <p>
-          We’re happy to help whether you’re ready to book or just comparing
-          options.
-        </p>
-        <div class="center-cta">
-          <a class="cta-button" href="/enquiry">Get My Quote</a>
-        </div>
-      </div>
-    </section>
-  </main>
-
-  <script is:inline>
-    /** @param {HTMLSelectElement} select */
-    function handleAreaSelect(select) {
-      if (select.value) window.location.href = select.value;
-    }
-  </script>
+    <script is:inline>
+      /** @param {HTMLSelectElement} select */
+      function handleAreaSelect(select) {
+        if (select.value) window.location.href = select.value;
+      }
+    </script>
+  </ServiceContent>
 
   <div class="sticky-cta">
     <a class="cta-button" href="/enquiry">Get a Quote</a>


### PR DESCRIPTION
## Summary
- wrap the home page inside ServiceContent for consistent spacing and remove legacy section/container wrappers
- restyle the hero quote form markup to match the service template and ensure the calculator stylesheet is loaded
- keep downstream sections aligned with the updated layout while preserving existing content and CTAs

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_b_68d395d4b86483238334bc9314e98927