### PR TITLE
Tighten included bedroom allowance

### DIFF
--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -193,7 +193,7 @@ export const SURVEYS: readonly SurveyDefinition[] = [
       'Clear next steps to resolve condensation, rising damp or leaks.',
       'Optional verification visit once remedial work is complete.',
     ],
-    bedroomsIncluded: 0,
+    bedroomsIncluded: 2,
     travelMultiplier: 0.75,
   },
   {
@@ -209,7 +209,7 @@ export const SURVEYS: readonly SurveyDefinition[] = [
       'Practical improvements tailored to the property layout.',
       'Advice on balancing heat recovery, trickle vents and extraction.',
     ],
-    bedroomsIncluded: 0,
+    bedroomsIncluded: 2,
     travelMultiplier: 0.7,
   },
   {
@@ -225,7 +225,7 @@ export const SURVEYS: readonly SurveyDefinition[] = [
       'High-quality floorplans supplied as PDF and JPG files.',
       'Guidance on quick-win efficiency improvements.',
     ],
-    bedroomsIncluded: 0,
+    bedroomsIncluded: 2,
     travelMultiplier: 0.55,
   },
   {
@@ -305,7 +305,7 @@ export const SURVEY_FEE_BANDS: readonly SurveyFeeBand[] = [
   {
     minValue: 0,
     maxValue: 150_000,
-    bedroomsIncluded: 4,
+    bedroomsIncluded: 2,
     level1: 325,
     level2: 450,
     level3: 625,
@@ -313,7 +313,7 @@ export const SURVEY_FEE_BANDS: readonly SurveyFeeBand[] = [
   {
     minValue: 150_001,
     maxValue: 250_000,
-    bedroomsIncluded: 4,
+    bedroomsIncluded: 2,
     level1: 370,
     level2: 515,
     level3: 675,
@@ -321,7 +321,7 @@ export const SURVEY_FEE_BANDS: readonly SurveyFeeBand[] = [
   {
     minValue: 250_001,
     maxValue: 400_000,
-    bedroomsIncluded: 4,
+    bedroomsIncluded: 2,
     level1: 390,
     level2: 545,
     level3: 735,
@@ -329,7 +329,7 @@ export const SURVEY_FEE_BANDS: readonly SurveyFeeBand[] = [
   {
     minValue: 400_001,
     maxValue: 600_000,
-    bedroomsIncluded: 4,
+    bedroomsIncluded: 2,
     level1: 410,
     level2: 645,
     level3: 825,
@@ -337,7 +337,7 @@ export const SURVEY_FEE_BANDS: readonly SurveyFeeBand[] = [
   {
     minValue: 600_001,
     maxValue: 850_000,
-    bedroomsIncluded: 4,
+    bedroomsIncluded: 2,
     level1: 625,
     level2: 685,
     level3: 1125,
@@ -345,7 +345,7 @@ export const SURVEY_FEE_BANDS: readonly SurveyFeeBand[] = [
   {
     minValue: 850_001,
     maxValue: 999_999,
-    bedroomsIncluded: 4,
+    bedroomsIncluded: 2,
     level1: 825,
     level2: 995,
     level3: 1500,
@@ -353,7 +353,7 @@ export const SURVEY_FEE_BANDS: readonly SurveyFeeBand[] = [
   {
     minValue: 1_000_000,
     maxValue: 1_500_000,
-    bedroomsIncluded: 4,
+    bedroomsIncluded: 2,
     level1: 925,
     level2: 1500,
     level3: 2100,
@@ -579,7 +579,7 @@ export const calculateQuote = ({
   // - Level surveys: take from fee band (SURVEY_FEE_BANDS). SURVEYS[].baseFee is ignored here by design.
   // - Non-level: use SURVEYS[].baseFee directly.
   let baseGross = survey.baseFee;
-  let bedroomsIncluded = survey.bedroomsIncluded ?? 3;
+  let bedroomsIncluded = survey.bedroomsIncluded ?? 2;
 
   if (isLevelSurvey && band) {
     const levelId = survey.id as (typeof LEVEL_SURVEYS)[number];

--- a/src/pricing.test.ts
+++ b/src/pricing.test.ts
@@ -67,7 +67,7 @@ describe('quote engine', () => {
     const result = calculateQuote({
       surveyType: 'level2',
       propertyValue: 250000,
-      bedrooms: 3,
+      bedrooms: 2,
       complexity: 'standard',
       distanceBandId: 'within-10-miles',
     });
@@ -96,10 +96,10 @@ describe('quote engine', () => {
       'extra-bedrooms',
       'distance',
     ]);
-    expect(result.total.gross).toBe(840);
-    expect(result.total.net).toBe(840);
+    expect(result.total.gross).toBe(900);
+    expect(result.total.net).toBe(900);
     expect(result.total.vat).toBe(0);
-    expect(result.range).toEqual({ min: 810, max: 870 });
+    expect(result.range).toEqual({ min: 870, max: 930 });
   });
 
   it('applies property metadata surcharges for a mid-terrace 1980s home', () => {
@@ -116,10 +116,11 @@ describe('quote engine', () => {
     expect(result.adjustments.map((entry) => [entry.id, entry.amount.gross])).toEqual([
       ['property-type', 10],
       ['property-age', 5],
+      ['extra-bedrooms', 30],
     ]);
     expect(result.adjustments.every((entry) => entry.amount.gross > 0)).toBe(true);
-    expect(result.total.gross).toBe(530);
-    expect(result.range).toEqual({ min: 500, max: 560 });
+    expect(result.total.gross).toBe(560);
+    expect(result.range).toEqual({ min: 530, max: 590 });
   });
 
   it('applies extension and distance surcharges for a Victorian detached home', () => {
@@ -137,10 +138,11 @@ describe('quote engine', () => {
     expect(result.adjustments.map((entry) => [entry.id, entry.amount.gross])).toEqual([
       ['property-type', 35],
       ['property-age', 50],
+      ['extra-bedrooms', 60],
       ['distance', 25],
     ]);
-    expect(result.total.gross).toBe(755);
-    expect(result.range).toEqual({ min: 725, max: 785 });
+    expect(result.total.gross).toBe(815);
+    expect(result.range).toEqual({ min: 785, max: 845 });
   });
 
   it('totals the larger surcharges for a complex level 3 survey', () => {
@@ -158,10 +160,10 @@ describe('quote engine', () => {
     expect(result.adjustments.map((entry) => [entry.id, entry.amount.gross])).toEqual([
       ['property-type', 35],
       ['property-age', 90],
-      ['extra-bedrooms', 30],
+      ['extra-bedrooms', 90],
       ['distance', 65],
     ]);
-    expect(result.total.gross).toBe(1345);
-    expect(result.range).toEqual({ min: 1295, max: 1395 });
+    expect(result.total.gross).toBe(1405);
+    expect(result.range).toEqual({ min: 1355, max: 1455 });
   });
 });


### PR DESCRIPTION
## Summary
- lower the included bedroom count to two across survey fee bands and non-level services
- default the pricing engine to two included bedrooms and update tests to reflect the tighter allowance

## Testing
- npm test *(fails: missing optional build dependencies in test harness)*

------
https://chatgpt.com/codex/tasks/task_b_68d6741b01d88323b459272996ea1300