### PR TITLE
Add Wrexham and North Wales location coverage

### DIFF
--- a/src/data/areas.ts
+++ b/src/data/areas.ts
@@ -68,6 +68,7 @@ const areaEntries: AreaLink[] = [
   createAreaEntry('north-west-of-england', 'North West of England'),
   createAreaEntry('northop', 'Northop'),
   createAreaEntry('northop-hall', 'Northop Hall'),
+  createAreaEntry('north-wales', 'North Wales'),
   createAreaEntry('oakenholt', 'Oakenholt'),
   createAreaEntry('penyffordd', 'Penyffordd'),
   createAreaEntry('prestbury', 'Prestbury'),
@@ -89,6 +90,7 @@ const areaEntries: AreaLink[] = [
   createAreaEntry('vicars-cross', 'Vicars Cross'),
   createAreaEntry('waverton', 'Waverton'),
   createAreaEntry('westminster-park', 'Westminster Park'),
+  createAreaEntry('wrexham', 'Wrexham'),
   createAreaEntry('wilmslow', 'Wilmslow'),
 ];
 
@@ -105,6 +107,8 @@ export const featuredAreas = [
   'flint',
   'hawarden',
   'queensferry',
+  'wrexham',
+  'north-wales',
 ];
 
 export const areaSelectorSlugs = [
@@ -121,6 +125,8 @@ export const areaSelectorSlugs = [
   'northop-hall',
   'mold',
   'north-west-of-england',
+  'wrexham',
+  'north-wales',
 ];
 
 export const getAreaBySlug = (slug: string) => areaLookup.get(slug);

--- a/src/pages/local-surveys.astro
+++ b/src/pages/local-surveys.astro
@@ -59,6 +59,14 @@ const areaParagraphs: Record<string, string[]> = {
   'vicars-cross': [
     'Our services in Vicars Cross include expert home, damp, and building surveys designed to maintain your property’s optimal condition.',
   ],
+  wrexham: [
+    'We support Wrexham homeowners with RICS Level 2 and Level 3 surveys, targeted damp investigations and measured surveys for renovations across the borough.',
+    'Explore how our Wrexham surveyor helps with terraces, rural homes and retrofit projects across North East Wales.',
+  ],
+  'north-wales': [
+    'North Wales clients rely on us for region-wide RICS surveys, damp diagnostics and measured building surveys that suit coastal and rural properties.',
+    'Discover our North Wales coverage, including bespoke advice for exposed locations, barn conversions and holiday lets.',
+  ],
 };
 
 const defaultParagraphs = (name: string) => [

--- a/src/pages/north-wales.astro
+++ b/src/pages/north-wales.astro
@@ -1,0 +1,206 @@
+---
+import LocationPageTemplate from '../components/location/LocationPageTemplate.astro';
+
+const townName = 'North Wales';
+const county = 'North Wales';
+const postalCode = '';
+const pageTitle = `${townName} Surveyors | LEM Building Surveying`;
+const metaDescription =
+  'RICS surveyor for North Wales providing Level 2 and Level 3 surveys, damp investigations and measured building surveys across coastal and rural communities.';
+const canonicalPath = 'north-wales';
+
+const hero = {
+  eyebrow: `${townName} Surveyors`,
+  heading: `RICS Surveys and Damp Specialists in ${townName}`,
+  description:
+    'Independent practice supporting homeowners, buyers and landlords across Flintshire, Denbighshire, Conwy and Gwynedd with detailed surveys, damp reports and measured building surveys.',
+  cta: {
+    label: `Book a ${townName} survey`,
+    href: '/enquiry',
+  },
+  secondaryCta: {
+    label: 'Call 07378 732037',
+    href: 'tel:07378732037',
+  },
+};
+
+const intro = [
+  `${townName} offers an array of property types—from seaside terraces and apartments to stone farmhouses and modern eco homes. We tailor every inspection so the survey level and reporting align with the construction and local exposure.`,
+  'Our reports address the realities of coastal weathering, tourism-led refurbishments and retrofitted insulation common across the region. Clients receive clear guidance on moisture control, structural care and maintenance planning.',
+  'Measured surveys and feasibility advice support renovation projects, barn conversions and planning submissions throughout the region, ensuring drawings and specifications start from accurate data.',
+];
+
+const sellingPoints = {
+  heading: `Why ${townName} clients choose LEM`,
+  points: [
+    'AssocRICS surveyor with hands-on experience across Flintshire, Denbighshire, Conwy and Gwynedd housing stock.',
+    'Balanced reporting that prioritises damp management, structural integrity and future maintenance for exposed locations.',
+    'Efficient scheduling that minimises travel delays and keeps purchase chains moving.',
+    'Direct communication with your surveyor from instruction through aftercare for rapid clarification.',
+  ],
+};
+
+const services = {
+  heading: `Specialist surveys across ${townName}`,
+  intro: 'RICS and diagnostic services tailored to varied landscapes and building styles across the region.',
+  items: [
+    {
+      name: 'RICS Level 2 Home Survey',
+      description: 'Thorough inspection and condition ratings suited to most modern houses, coastal terraces and village homes.',
+    },
+    {
+      name: 'RICS Level 3 Building Survey',
+      description:
+        'Detailed structural analysis for listed buildings, stone farmhouses, converted chapels and complex renovations.',
+    },
+    {
+      name: 'RICS Level 1 Condition Report',
+      description: 'Concise reporting for newer developments and investment apartments needing independent verification.',
+    },
+    {
+      name: 'Independent Damp & Timber Investigation',
+      description: 'Identify salt contamination, driving rain and ventilation issues in exposed coastal and upland homes.',
+    },
+    {
+      name: 'Ventilation & Indoor Air Quality Review',
+      description: 'Ensure mechanical and natural ventilation strategies cope with airtight retrofits and holiday-let occupancy.',
+    },
+    {
+      name: 'Measured Surveys & CAD Plans',
+      description: 'Accurate plans and sections for extensions, conversions and compliance submissions throughout North Wales.',
+    },
+  ],
+};
+
+const localInsights = {
+  heading: `Survey considerations unique to ${townName}`,
+  paragraphs: [
+    'Coastal towns contend with wind-driven rain, salt-laden air and maintenance backlogs. We highlight detailing that protects masonry, render and joinery.',
+    'Rural farmhouses and barns often have mixed materials and piecemeal upgrades. We review structure, moisture and ventilation to keep traditional fabric breathable.',
+    'Tourism and holiday-let conversions bring intensive usage. We assess fire safety, sound insulation and drainage to ensure properties remain compliant.',
+  ],
+};
+
+const additionalInsights = [
+  {
+    heading: 'Support for planners and designers',
+    paragraphs: [
+      'Measured surveys feed into architectural design, structural calculations and heritage applications across the region.',
+      'We coordinate with local architects and contractors to ensure retrofit and extension plans respect conservation requirements.',
+    ],
+  },
+  {
+    heading: 'Aftercare and guidance',
+    paragraphs: [
+      'Post-survey calls walk you through priorities, negotiations and contractor briefs.',
+      'Need evidence for a lender, insurer or grant application? We prepare supplementary notes that keep paperwork aligned.',
+    ],
+  },
+];
+
+const internalLinks = {
+  heading: `Popular services for ${townName} homeowners`,
+  description: 'Explore the key services North Wales clients regularly request.',
+  links: [
+    {
+      label: 'RICS Level 2 Home Survey',
+      href: '/level-2',
+      description: 'Discover how our Level 2 surveys support confident decisions across the region.',
+    },
+    {
+      label: 'RICS Level 3 Building Survey',
+      href: '/level-3',
+      description: 'Learn why complex and historic buildings benefit from comprehensive reporting.',
+    },
+    {
+      label: 'Damp & Timber Surveys',
+      href: '/damp-timber-surveys',
+      description: 'Independent diagnosis for damp-prone coastal and upland homes.',
+    },
+    {
+      label: 'Ventilation Assessments',
+      href: '/ventilation-assessments',
+      description: 'Tailored ventilation guidance for well-sealed or high-occupancy properties.',
+    },
+    {
+      label: 'Measured Surveys',
+      href: '/measured-surveys',
+      description: 'Precision data for extensions, conversions and compliance across North Wales.',
+    },
+  ],
+};
+
+const faqs = {
+  heading: `${townName} property FAQs`,
+  items: [
+    {
+      question: 'Which areas of North Wales do you cover?',
+      answer:
+        'We travel throughout Flintshire, Denbighshire, Conwy, Gwynedd and Anglesey, including rural villages and coastal towns.',
+    },
+    {
+      question: 'Can you investigate damp in exposed coastal homes?',
+      answer:
+        'Yes. We assess salt attack, pointing, guttering and ventilation to pinpoint causes and recommend practical solutions.',
+    },
+    {
+      question: 'Do you offer measured surveys for planning submissions?',
+      answer:
+        'Absolutely. Our laser-measured drawings support extensions, barn conversions and lease plans.',
+    },
+    {
+      question: 'How soon will I receive my RICS report?',
+      answer: 'Most surveys are delivered within four working days, with expedited services available when timelines are tight.',
+    },
+  ],
+};
+
+const neighbourhoods = {
+  heading: `Areas covered across ${townName}`,
+  description: 'We work throughout North Wales, regularly visiting:',
+  areas: [
+    'Flintshire towns including Mold, Buckley and Holywell',
+    'Denbighshire and Conwy coastal resorts such as Rhyl, Prestatyn and Llandudno',
+    'Gwynedd communities including Bangor, Caernarfon and the Llŷn Peninsula',
+    'Anglesey villages and rural mainland hamlets',
+  ],
+};
+
+const closing = {
+  heading: `Arrange your ${townName} survey`,
+  paragraphs: [
+    'Tell us about the property, timescales and any known issues. We will recommend the right level of inspection and confirm fees upfront.',
+    'From booking to follow-up conversations you deal directly with Liam, ensuring consistent advice wherever your property sits in North Wales.',
+  ],
+  primaryCta: {
+    label: `Book a ${townName} survey`,
+    href: '/enquiry',
+  },
+  secondaryCta: {
+    label: 'Call 07378 732037',
+    href: 'tel:07378732037',
+  },
+};
+
+const mapEmbedUrl = 'https://www.google.com/maps?q=North+Wales,+UK&output=embed';
+---
+
+<LocationPageTemplate
+  townName={townName}
+  county={county}
+  postalCode={postalCode}
+  pageTitle={pageTitle}
+  metaDescription={metaDescription}
+  canonicalPath={canonicalPath}
+  hero={hero}
+  intro={intro}
+  sellingPoints={sellingPoints}
+  services={services}
+  internalLinks={internalLinks}
+  localInsights={localInsights}
+  additionalInsights={additionalInsights}
+  faqs={faqs}
+  neighbourhoods={neighbourhoods}
+  closing={closing}
+  mapEmbedUrl={mapEmbedUrl}
+/>

--- a/src/pages/wrexham.astro
+++ b/src/pages/wrexham.astro
@@ -1,0 +1,206 @@
+---
+import LocationPageTemplate from '../components/location/LocationPageTemplate.astro';
+
+const townName = 'Wrexham';
+const county = 'Wrexham County Borough';
+const postalCode = '';
+const pageTitle = `${townName} Surveyors | LEM Building Surveying`;
+const metaDescription =
+  'Independent Wrexham surveyor delivering RICS home surveys, damp investigations and measured building surveys for town and village properties.';
+const canonicalPath = 'wrexham';
+
+const hero = {
+  eyebrow: `${townName} Surveyors`,
+  heading: `Home, Damp and Measured Surveys in ${townName}`,
+  description:
+    `AssocRICS surveyor covering ${townName}, Rhos, Gresford and surrounding villages with detailed RICS reports, damp diagnostics and accurate measured surveys.`,
+  cta: {
+    label: `Book a ${townName} survey`,
+    href: '/enquiry',
+  },
+  secondaryCta: {
+    label: 'Call 07378 732037',
+    href: 'tel:07378732037',
+  },
+};
+
+const intro = [
+  `${townName} combines Victorian terraces, post-war estates and rural farmhouses that each need a tailored inspection approach. We review build dates, extensions and alterations so the chosen survey level reflects real risks.`,
+  `Buyers and homeowners across ${townName} regularly instruct RICS Level 2 and Level 3 surveys to understand damp issues, structural changes and retrofit upgrades before committing to works.`,
+  `From town centre conversions to modern developments in nearby villages, we deliver independent reporting that highlights priorities, costs and compliance considerations.`,
+];
+
+const sellingPoints = {
+  heading: `Why ${townName} clients choose LEM`,
+  points: [
+    `AssocRICS surveyor with first-hand knowledge of ${townName}'s terraces, non-standard rural homes and new estates.`,
+    'Balanced advice that breaks down urgent repairs, damp risks and future maintenance in plain language.',
+    'Flexible scheduling across North East Wales to coordinate with agents, tenants and renovation timelines.',
+    'Direct access to your surveyor before and after inspection for follow-up questions and planning support.',
+  ],
+};
+
+const services = {
+  heading: `Survey services across ${townName}`,
+  intro: `RICS and specialist inspections tailored to the property styles found throughout ${townName} and its villages.`,
+  items: [
+    {
+      name: 'RICS Level 2 Home Survey',
+      description: `Ideal for most houses and apartments in ${townName}, providing condition ratings, moisture observations and practical repair advice.`,
+    },
+    {
+      name: 'RICS Level 3 Building Survey',
+      description:
+        'Full structural appraisal for historic cottages, converted chapels or extensively altered homes where damp and movement need deeper investigation.',
+    },
+    {
+      name: 'RICS Level 1 Condition Report',
+      description: 'Concise overview for well-maintained modern builds that still benefit from an independent check.',
+    },
+    {
+      name: 'Independent Damp & Timber Investigation',
+      description: 'Root-cause diagnosis of penetrating damp, condensation and timber decay common in valley terraces and countryside properties.',
+    },
+    {
+      name: 'Ventilation & Indoor Air Quality Review',
+      description: 'Assess extractor performance, trickle vents and air pathways to help homes cope with modern insulation upgrades.',
+    },
+    {
+      name: 'Measured Surveys & CAD Plans',
+      description: `Accurate floor plans and elevations to support extensions, barn conversions and lease plans throughout ${townName}.`,
+    },
+  ],
+};
+
+const localInsights = {
+  heading: `What to watch for in ${townName}`,
+  paragraphs: [
+    `${townName}'s terraces and cottages often show historic movement and patch repairs. We review masonry, lintels and roof structures to ensure issues are properly recorded.`,
+    'Floodplains around the Clywedog and Alyn valleys demand attention to drainage, damp-proofing and ventilation. We highlight realistic mitigation steps.',
+    'Conversions and extensions are popular across the borough. We examine detailing, approvals and workmanship so you understand long-term implications.',
+  ],
+};
+
+const additionalInsights = [
+  {
+    heading: 'Support for renovation and retrofit projects',
+    paragraphs: [
+      'We advise on insulation upgrades, heating changes and ventilation strategies so improvements reduce damp risk rather than increase it.',
+      'Measured surveys provide accurate baselines for planning drawings, steel designs or heritage consent submissions.',
+    ],
+  },
+  {
+    heading: 'Client care throughout the process',
+    paragraphs: [
+      'You receive the report directly from your surveyor along with follow-up time to discuss findings, quotes and negotiations.',
+      'Need written clarification for a lender or contractor? We provide targeted addenda that help keep your timeline on track.',
+    ],
+  },
+];
+
+const internalLinks = {
+  heading: `Popular services for ${townName} homeowners`,
+  description: 'Dig deeper into the specialist surveys we provide across Wrexham and the surrounding villages.',
+  links: [
+    {
+      label: 'RICS Level 2 Home Survey',
+      href: '/level-2',
+      description: `See how our Level 2 reports support confident decisions in ${townName}.`,
+    },
+    {
+      label: 'RICS Level 3 Building Survey',
+      href: '/level-3',
+      description: 'Understand the benefits of an in-depth structural inspection for complex properties.',
+    },
+    {
+      label: 'Damp & Timber Surveys',
+      href: '/damp-timber-surveys',
+      description: 'Independent damp diagnosis across North East Wales.',
+    },
+    {
+      label: 'Ventilation Assessments',
+      href: '/ventilation-assessments',
+      description: 'Keep retrofitted homes balanced with tailored airflow advice.',
+    },
+    {
+      label: 'Measured Surveys',
+      href: '/measured-surveys',
+      description: 'Obtain CAD-ready plans for extensions, conversions and lease agreements.',
+    },
+  ],
+};
+
+const faqs = {
+  heading: `${townName} property FAQs`,
+  items: [
+    {
+      question: `Do you cover all of ${townName} and nearby villages?`,
+      answer:
+        'Yes. We inspect homes across the town centre, Rhosllanerchrugog, Gresford, Coedpoeth, Ruabon and throughout the wider borough.',
+    },
+    {
+      question: 'Can you investigate damp and mould in older terraces?',
+      answer:
+        'Absolutely. We combine moisture profiling with ventilation checks to identify causes and recommend realistic remedial options.',
+    },
+    {
+      question: 'Do you provide measured surveys for planning applications?',
+      answer:
+        'Yes, we capture accurate dimensions and elevations to support extensions, conversions and compliance submissions.',
+    },
+    {
+      question: 'How quickly will I receive my report?',
+      answer: 'Most reports are issued within four working days, with faster turnaround available when chains require it.',
+    },
+  ],
+};
+
+const neighbourhoods = {
+  heading: `Areas covered in and around ${townName}`,
+  description: 'We survey Wrexham County Borough and neighbouring communities, including:',
+  areas: [
+    'Wrexham city centre and Acton',
+    'Rhosllanerchrugog, Johnstown and Ruabon',
+    'Gresford, Marford and Rossett',
+    'Coedpoeth, Minera and Bwlchgwyn',
+  ],
+};
+
+const closing = {
+  heading: `Arrange your ${townName} survey`,
+  paragraphs: [
+    'Share your objectives, timescales and any known concerns. We will recommend the most suitable inspection and confirm a fixed fee.',
+    'You work directly with Liam throughout—from booking and site access to post-survey calls—so you receive consistent, practical advice.',
+  ],
+  primaryCta: {
+    label: `Book a ${townName} survey`,
+    href: '/enquiry',
+  },
+  secondaryCta: {
+    label: 'Call 07378 732037',
+    href: 'tel:07378732037',
+  },
+};
+
+const mapEmbedUrl = 'https://www.google.com/maps?q=Wrexham,+UK&output=embed';
+---
+
+<LocationPageTemplate
+  townName={townName}
+  county={county}
+  postalCode={postalCode}
+  pageTitle={pageTitle}
+  metaDescription={metaDescription}
+  canonicalPath={canonicalPath}
+  hero={hero}
+  intro={intro}
+  sellingPoints={sellingPoints}
+  services={services}
+  internalLinks={internalLinks}
+  localInsights={localInsights}
+  additionalInsights={additionalInsights}
+  faqs={faqs}
+  neighbourhoods={neighbourhoods}
+  closing={closing}
+  mapEmbedUrl={mapEmbedUrl}
+/>


### PR DESCRIPTION
## Summary
- add dedicated location pages for Wrexham and North Wales highlighting RICS surveys, damp services and measured survey support
- register the new areas within the shared area data so navigation, featured lists and selectors surface the pages
- supply bespoke teaser copy on the local surveys page for the new locations

## Testing
- npm run check *(fails: missing @astrojs/mdx module in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d6775fe8c4832392c1acc004c4eab8