### PR TITLE
Clarify Level 2 homebuyer survey messaging

### DIFF
--- a/src/pages/level-2.astro
+++ b/src/pages/level-2.astro
@@ -6,7 +6,7 @@ const levelTwoFaqs = [
   {
     question: 'What does a Level 2 HomeBuyer Report include?',
     answer:
-      'A Level 2 HomeBuyer Report covers a visual inspection of the building fabric, roofs, services and outbuildings, highlights significant defects, and explains priorities for repair or maintenance with annotated photographs and moisture readings where relevant.',
+      'This Level 2 homebuyer survey covers a visual inspection of the building fabric, roofs, services and outbuildings, highlights significant defects, and explains priorities for repair or maintenance with annotated photographs and moisture readings where relevant.',
   },
   {
     question: 'Which properties are suitable for a Level 2 survey?',
@@ -31,7 +31,7 @@ const levelTwoFaqs = [
 ];
 
 const description =
-  'Buying a typical home in Chester or Deeside? Our RICS Level 2 HomeBuyer Report highlights defects, repair priorities and moisture risks without upsells.';
+  'Buying a typical home in Chester or Deeside? Our RICS Level 2 HomeBuyer Report (homebuyer survey) highlights defects, repair priorities and moisture risks without upsells.';
 
 const { seo: baseSeo, pageUrl } = createServiceSeo({
   title: 'RICS Level 2 HomeBuyer Report | LEM Building Surveying',
@@ -85,8 +85,8 @@ const seo = {
     <div class="hero-container">
       <h1>RICS Level 2 HomeBuyer Report</h1>
       <p>
-        Clear, practical advice for typical homes—ideal for buyers who want
-        peace of mind and negotiation power.
+        Clear, practical advice from a RICS Level 2 HomeBuyer Report (homebuyer
+        survey)—ideal for buyers who want peace of mind and negotiation power.
       </p>
       <a class="cta-button" href="/enquiry">Book Your Survey</a>
     </div>
@@ -198,11 +198,11 @@ const seo = {
       <details>
         <summary>What does a Level 2 HomeBuyer Report include?</summary>
         <p>
-          A Level 2 HomeBuyer Report covers the major elements of the property.
-          We assess the structure, roof coverings, joinery, services and damp
-          risks, then explain which issues need immediate action and which are
-          routine maintenance. Photographs and moisture readings are included to
-          give you evidence for negotiations.
+          This Level 2 homebuyer survey covers the major elements of the
+          property. We assess the structure, roof coverings, joinery, services
+          and damp risks, then explain which issues need immediate action and
+          which are routine maintenance. Photographs and moisture readings are
+          included to give you evidence for negotiations.
         </p>
       </details>
       <details>


### PR DESCRIPTION
## Summary
- Update the Level 2 hero copy to explicitly reference the RICS homebuyer survey naming.
- Add the "homebuyer survey" keyword to the page meta description for SEO alignment.
- Mention the homebuyer survey within FAQs to reinforce context for readers and schema data.

## Testing
- `npm run build:assets` *(fails: missing cssnano dependency)*

------
https://chatgpt.com/codex/tasks/task_b_68d67b0203e88323a92bab8562558e0a