### PR TITLE
Add Service structured data to damp mould surveys page

### DIFF
--- a/src/pages/damp-mould-surveys.astro
+++ b/src/pages/damp-mould-surveys.astro
@@ -2,6 +2,52 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { areaSelectorOptions } from '../data/areas';
 
+const pageUrl = 'https://lembuildingsurveying.co.uk/damp-mould-surveys';
+
+const serviceSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Service',
+  name: 'Damp & Mould Surveys',
+  serviceType: 'Damp & Mould Surveys',
+  description:
+    'Independent damp and mould surveys with impartial diagnosis, actionable reports, and fixed-fee pricing across North Wales and Cheshire.',
+  provider: {
+    '@type': 'LocalBusiness',
+    name: 'LEM Building Surveying Ltd',
+    image: 'https://lembuildingsurveying.co.uk/logo.png',
+    logo: 'https://lembuildingsurveying.co.uk/logo.png',
+    url: 'https://lembuildingsurveying.co.uk',
+    telephone: '+44-7378-732037',
+    address: {
+      '@type': 'PostalAddress',
+      streetAddress: 'Marlowe Avenue',
+      addressLocality: 'Deeside',
+      addressRegion: 'Flintshire',
+      postalCode: 'CH5 4HS',
+      addressCountry: 'UK',
+    },
+    geo: {
+      '@type': 'GeoCoordinates',
+      latitude: '53.1913',
+      longitude: '-2.8919',
+    },
+    sameAs: [
+      'https://www.facebook.com/share/1DZpcsZUUB/',
+      'https://www.linkedin.com/company/lem-building-surveying-ltd/',
+    ],
+  },
+  areaServed: {
+    '@type': 'Place',
+    name: 'Flintshire, Chester, Cheshire, Wrexham, North Wales',
+  },
+  offers: {
+    '@type': 'Offer',
+    url: pageUrl,
+    priceCurrency: 'GBP',
+  },
+  url: pageUrl,
+};
+
 const dampFaqs = [
   {
     question: 'Can a survey identify black mould causes?',
@@ -48,7 +94,7 @@ const seo = {
     'Expert damp and mould surveys with actionable reports. Serving Flintshire, Wrexham & Cheshire. Fixed-fee service.',
   canonicalPath: '/damp-mould-surveys',
   fullTitle: true,
-  structuredData: [faqSchema],
+  structuredData: [serviceSchema, faqSchema],
 };
 ---
 


### PR DESCRIPTION
## Summary
- add a Service JSON-LD schema for the damp & mould surveys page using the existing business details
- include the Service schema alongside the FAQ structured data so both blocks render

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d7a78a27148323a895f5abbaf42fa6