### PR TITLE
Fix LocalBusiness schema structure on location pages

### DIFF
--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -77,28 +77,6 @@ export const createLocationSeo = ({
       name: primaryAreaName,
     },
     description: localBusiness.description,
-    faq: {
-      '@context': 'https://schema.org',
-      '@type': 'FAQPage',
-      mainEntity: [
-        {
-          '@type': 'Question',
-          name: `Do you cover ${primaryAreaName} properties?`,
-          acceptedAnswer: {
-            '@type': 'Answer',
-            text: `Yes, we provide RICS Home Surveys (Levels 1, 2, 3) and Damp Reports for properties in ${primaryAreaName}.`,
-          },
-        },
-        {
-          '@type': 'Question',
-          name: `Can I get an instant quote for a survey in ${primaryAreaName}?`,
-          acceptedAnswer: {
-            '@type': 'Answer',
-            text: `Yes, our online calculator provides instant, fixed-fee quotes for surveys in ${primaryAreaName}.`,
-          },
-        },
-      ],
-    },
   };
 
   return {


### PR DESCRIPTION
## Summary
- remove the embedded FAQ schema from the LocalBusiness structured data emitted on location pages
- rely on the existing dedicated FAQPage structured data block so each schema type is output in its own script tag

## Testing
- npm test *(fails: pre-existing pricing quote expectations)*

------
https://chatgpt.com/codex/tasks/task_b_68d7b386fa508323b1231161251b0175