### PR TITLE
Add shared aggregate rating constants for LocalBusiness schemas

### DIFF
--- a/src/pages/damp-mould-surveys.astro
+++ b/src/pages/damp-mould-surveys.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { areaSelectorOptions } from '../data/areas';
+import { BUSINESS_AGGREGATE_RATING } from '../utils/structuredData';
 
 const pageUrl = 'https://lembuildingsurveying.co.uk/damp-mould-surveys';
 
@@ -35,6 +36,7 @@ const serviceSchema = {
       'https://www.facebook.com/share/1DZpcsZUUB/',
       'https://www.linkedin.com/company/lem-building-surveying-ltd/',
     ],
+    aggregateRating: { ...BUSINESS_AGGREGATE_RATING },
   },
   areaServed: {
     '@type': 'Place',

--- a/src/pages/damp-surveys-index.astro
+++ b/src/pages/damp-surveys-index.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import { BUSINESS_AGGREGATE_RATING } from '../utils/structuredData';
 
 const pageUrl = 'https://lembuildingsurveying.co.uk/damp-surveys-index';
 
@@ -34,6 +35,7 @@ const serviceSchema = {
       'https://www.facebook.com/share/1DZpcsZUUB/',
       'https://www.linkedin.com/company/lem-building-surveying-ltd/',
     ],
+    aggregateRating: { ...BUSINESS_AGGREGATE_RATING },
   },
   areaServed: {
     '@type': 'Place',

--- a/src/pages/level-1.astro
+++ b/src/pages/level-1.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import { BUSINESS_AGGREGATE_RATING } from '../utils/structuredData';
 
 const pageUrl = 'https://lembuildingsurveying.co.uk/level-1';
 
@@ -34,6 +35,7 @@ const serviceSchema = {
       'https://www.facebook.com/share/1DZpcsZUUB/',
       'https://www.linkedin.com/company/lem-building-surveying-ltd/',
     ],
+    aggregateRating: { ...BUSINESS_AGGREGATE_RATING },
   },
   areaServed: {
     '@type': 'Place',

--- a/src/pages/level-2.astro
+++ b/src/pages/level-2.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import { BUSINESS_AGGREGATE_RATING } from '../utils/structuredData';
 
 const pageUrl = 'https://lembuildingsurveying.co.uk/level-2';
 
@@ -34,6 +35,7 @@ const serviceSchema = {
       'https://www.facebook.com/share/1DZpcsZUUB/',
       'https://www.linkedin.com/company/lem-building-surveying-ltd/',
     ],
+    aggregateRating: { ...BUSINESS_AGGREGATE_RATING },
   },
   areaServed: {
     '@type': 'Place',

--- a/src/pages/level-3.astro
+++ b/src/pages/level-3.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import { BUSINESS_AGGREGATE_RATING } from '../utils/structuredData';
 
 const pageUrl = 'https://lembuildingsurveying.co.uk/level-3';
 
@@ -34,6 +35,7 @@ const serviceSchema = {
       'https://www.facebook.com/share/1DZpcsZUUB/',
       'https://www.linkedin.com/company/lem-building-surveying-ltd/',
     ],
+    aggregateRating: { ...BUSINESS_AGGREGATE_RATING },
   },
   areaServed: {
     '@type': 'Place',

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -1,4 +1,8 @@
-import { SCHEMA_LOGO_URL, SITE_URL } from './structuredData';
+import {
+  BUSINESS_AGGREGATE_RATING,
+  SCHEMA_LOGO_URL,
+  SITE_URL,
+} from './structuredData';
 
 interface LocationSeoOptions {
   title: string;
@@ -77,6 +81,7 @@ export const createLocationSeo = ({
       name: primaryAreaName,
     },
     description: localBusiness.description,
+    aggregateRating: { ...BUSINESS_AGGREGATE_RATING },
   };
 
   return {

--- a/src/utils/structuredData.ts
+++ b/src/utils/structuredData.ts
@@ -14,6 +14,17 @@ export const SOCIAL_PROFILES = [
   'https://www.linkedin.com/company/lem-building-surveying-ltd/',
 ];
 
+export const BUSINESS_RATING_VALUE = '5';
+export const BUSINESS_REVIEW_COUNT = 5;
+
+export const BUSINESS_AGGREGATE_RATING = {
+  '@type': 'AggregateRating',
+  ratingValue: BUSINESS_RATING_VALUE,
+  reviewCount: BUSINESS_REVIEW_COUNT,
+  bestRating: '5',
+  worstRating: '1',
+} as const;
+
 const REVIEWS = [
   {
     '@type': 'Review',
@@ -116,6 +127,7 @@ export const buildLocalBusinessSchema = (overrides: Record<string, unknown> = {}
   ],
   sameAs: SOCIAL_PROFILES,
   review: REVIEWS,
+  aggregateRating: { ...BUSINESS_AGGREGATE_RATING },
   ...overrides,
 });
 


### PR DESCRIPTION
## Summary
- add shared business-wide aggregate rating constants to the structured data utilities
- include the aggregateRating block in the LocalBusiness schema builder and every manual LocalBusiness definition
- update the location SEO helper to spread the shared aggregate rating so all pages emit consistent data

## Testing
- `npm run build` *(fails: cannot find package 'cssnano' required by tools/build-assets.mjs)*

------
https://chatgpt.com/codex/tasks/task_b_68d7c58b2f0c8323929215fd0efd0cf9