### PR TITLE
Add Product structured data for survey pages

### DIFF
--- a/src/components/Seo.astro
+++ b/src/components/Seo.astro
@@ -153,6 +153,9 @@ if (breadcrumbItems.length > 0) {
     })),
   });
 }
+const structuredDataJsonBlocks = structuredDataBlocks.map((schema) =>
+  JSON.stringify(schema),
+);
 const alternateLinks = [...alternates];
 const metaEntries = [...additionalMeta];
 ---
@@ -186,10 +189,10 @@ const metaEntries = [...additionalMeta];
 {metaEntries.map((meta: AdditionalMetaTag) => (
   <meta {...meta} />
 ))}
-{structuredDataBlocks.map((schema) => (
+{structuredDataJsonBlocks.map((schemaJson) => (
   <script
     type="application/ld+json"
     is:inline
-    set:html={JSON.stringify(schema)}
+    set:html={schemaJson}
   ></script>
 ))}

--- a/src/data/googleReviews.ts
+++ b/src/data/googleReviews.ts
@@ -1,0 +1,70 @@
+export const GOOGLE_REVIEWS = [
+  {
+    '@type': 'Review',
+    name: 'Google review by Lindsey M.',
+    url: 'https://share.google/Ab6iUZ0rNTNvHr2xa',
+    datePublished: '2024-02-10',
+    reviewBody:
+      'We used Liam to carry out a Level 2 Survey on a property we are purchasing. We found him very responsive, professional and knowledgeable. Liam highlighted issues without frightening us, offering advice on how to move forward. Would highly recommend him.',
+    author: {
+      '@type': 'Person',
+      name: 'Lindsey M.',
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: 'Google',
+    },
+    reviewRating: {
+      '@type': 'Rating',
+      ratingValue: '5',
+      bestRating: '5',
+      worstRating: '1',
+    },
+  },
+  {
+    '@type': 'Review',
+    name: 'Google review by Chris S.',
+    url: 'https://share.google/Ab6iUZ0rNTNvHr2xa',
+    datePublished: '2024-03-18',
+    reviewBody:
+      'LEM provided an excellent service from start to finish. His report was clear and explained everything simply and with enough detail for me to make informed choices. I would recommend LEM to anyone needing Building Surveying services.',
+    author: {
+      '@type': 'Person',
+      name: 'Chris S.',
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: 'Google',
+    },
+    reviewRating: {
+      '@type': 'Rating',
+      ratingValue: '5',
+      bestRating: '5',
+      worstRating: '1',
+    },
+  },
+  {
+    '@type': 'Review',
+    name: 'Google review by Helen H.',
+    url: 'https://share.google/Ab6iUZ0rNTNvHr2xa',
+    datePublished: '2024-04-22',
+    reviewBody:
+      'Liam was fantastic—professional, efficient, and really knowledgeable. He explained everything clearly, which made the whole process much easier. I’d definitely recommend LEM Building Surveying to anyone needing EPCs, floorplans, or a property survey. A smooth and stress-free experience from start to finish!',
+    author: {
+      '@type': 'Person',
+      name: 'Helen H.',
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: 'Google',
+    },
+    reviewRating: {
+      '@type': 'Rating',
+      ratingValue: '5',
+      bestRating: '5',
+      worstRating: '1',
+    },
+  },
+] as const;
+
+export type GoogleReview = (typeof GOOGLE_REVIEWS)[number];

--- a/src/pages/damp-mould-surveys.astro
+++ b/src/pages/damp-mould-surveys.astro
@@ -2,51 +2,32 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { areaSelectorOptions } from '../data/areas';
 import { BUSINESS_AGGREGATE_RATING } from '../utils/structuredData';
+import { GOOGLE_REVIEWS } from '../data/googleReviews';
 
 const pageUrl = 'https://lembuildingsurveying.co.uk/damp-mould-surveys';
 
-const serviceSchema = {
+const productSchema = {
   '@context': 'https://schema.org',
-  '@type': 'Service',
-  name: 'Damp & Mould Surveys',
-  serviceType: 'Damp & Mould Surveys',
+  '@type': 'Product',
+  name: 'Damp & Mould Survey',
   description:
     'Independent damp and mould surveys with impartial diagnosis, actionable reports, and fixed-fee pricing across North Wales and Cheshire.',
-  provider: {
-    '@type': 'LocalBusiness',
+  sku: 'LEM-DAMP-MOULD',
+  brand: {
+    '@type': 'Organization',
     name: 'LEM Building Surveying Ltd',
-    image: 'https://lembuildingsurveying.co.uk/logo.png',
-    logo: 'https://lembuildingsurveying.co.uk/logo.png',
     url: 'https://lembuildingsurveying.co.uk',
-    telephone: '+44-7378-732037',
-    address: {
-      '@type': 'PostalAddress',
-      streetAddress: 'Marlowe Avenue',
-      addressLocality: 'Deeside',
-      addressRegion: 'Flintshire',
-      postalCode: 'CH5 4HS',
-      addressCountry: 'UK',
-    },
-    geo: {
-      '@type': 'GeoCoordinates',
-      latitude: '53.1913',
-      longitude: '-2.8919',
-    },
-    sameAs: [
-      'https://www.facebook.com/share/1DZpcsZUUB/',
-      'https://www.linkedin.com/company/lem-building-surveying-ltd/',
-    ],
-    aggregateRating: { ...BUSINESS_AGGREGATE_RATING },
-  },
-  areaServed: {
-    '@type': 'Place',
-    name: 'Flintshire, Chester, Cheshire, Wrexham, North Wales',
   },
   offers: {
     '@type': 'Offer',
     url: pageUrl,
     priceCurrency: 'GBP',
+    price: '525',
+    availability: 'https://schema.org/InStock',
+    itemCondition: 'https://schema.org/NewCondition',
   },
+  aggregateRating: { ...BUSINESS_AGGREGATE_RATING },
+  review: GOOGLE_REVIEWS,
   url: pageUrl,
 };
 
@@ -96,7 +77,7 @@ const seo = {
     'Expert damp and mould surveys with actionable reports. Serving Flintshire, Wrexham & Cheshire. Fixed-fee service.',
   canonicalPath: '/damp-mould-surveys',
   fullTitle: true,
-  structuredData: [serviceSchema, faqSchema],
+  structuredData: [productSchema, faqSchema],
 };
 ---
 

--- a/src/pages/level-1.astro
+++ b/src/pages/level-1.astro
@@ -1,51 +1,32 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { BUSINESS_AGGREGATE_RATING } from '../utils/structuredData';
+import { GOOGLE_REVIEWS } from '../data/googleReviews';
 
 const pageUrl = 'https://lembuildingsurveying.co.uk/level-1';
 
-const serviceSchema = {
+const productSchema = {
   '@context': 'https://schema.org',
-  '@type': 'Service',
+  '@type': 'Product',
   name: 'RICS Level 1 Survey (Condition Report)',
-  serviceType: 'RICS Level 1 Survey (Condition Report)',
   description:
     'Independent RICS Condition Reports for modern homes. Clear traffic-light results. Fixed fees, fast reports.',
-  provider: {
-    '@type': 'LocalBusiness',
+  sku: 'LEM-L1-SURVEY',
+  brand: {
+    '@type': 'Organization',
     name: 'LEM Building Surveying Ltd',
-    image: 'https://lembuildingsurveying.co.uk/logo.png',
-    logo: 'https://lembuildingsurveying.co.uk/logo.png',
     url: 'https://lembuildingsurveying.co.uk',
-    telephone: '+44-7378-732037',
-    address: {
-      '@type': 'PostalAddress',
-      streetAddress: 'Marlowe Avenue',
-      addressLocality: 'Deeside',
-      addressRegion: 'Flintshire',
-      postalCode: 'CH5 4HS',
-      addressCountry: 'UK',
-    },
-    geo: {
-      '@type': 'GeoCoordinates',
-      latitude: '53.1913',
-      longitude: '-2.8919',
-    },
-    sameAs: [
-      'https://www.facebook.com/share/1DZpcsZUUB/',
-      'https://www.linkedin.com/company/lem-building-surveying-ltd/',
-    ],
-    aggregateRating: { ...BUSINESS_AGGREGATE_RATING },
-  },
-  areaServed: {
-    '@type': 'Place',
-    name: 'Flintshire, Chester, Cheshire, Wrexham, North Wales',
   },
   offers: {
     '@type': 'Offer',
     url: pageUrl,
     priceCurrency: 'GBP',
+    price: '325',
+    availability: 'https://schema.org/InStock',
+    itemCondition: 'https://schema.org/NewCondition',
   },
+  aggregateRating: { ...BUSINESS_AGGREGATE_RATING },
+  review: GOOGLE_REVIEWS,
   url: pageUrl,
 };
 
@@ -69,7 +50,7 @@ const seo = {
   description: 'Independent RICS Condition Reports for modern homes. Clear traffic-light results. Fixed fees, fast reports.',
   canonicalPath: '/level-1',
   fullTitle: true,
-  structuredData: [serviceSchema, faqSchema],
+  structuredData: [productSchema, faqSchema],
 };
 ---
 

--- a/src/pages/level-2.astro
+++ b/src/pages/level-2.astro
@@ -1,51 +1,32 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { BUSINESS_AGGREGATE_RATING } from '../utils/structuredData';
+import { GOOGLE_REVIEWS } from '../data/googleReviews';
 
 const pageUrl = 'https://lembuildingsurveying.co.uk/level-2';
 
-const serviceSchema = {
+const productSchema = {
   '@context': 'https://schema.org',
-  '@type': 'Service',
+  '@type': 'Product',
   name: 'RICS HomeBuyer Survey (Level 2)',
-  serviceType: 'RICS HomeBuyer Survey (Level 2)',
   description:
     'Most popular RICS survey. Photos + advice. Serving Chester, Mold, Flintshire. Get an instant quote online.',
-  provider: {
-    '@type': 'LocalBusiness',
+  sku: 'LEM-L2-SURVEY',
+  brand: {
+    '@type': 'Organization',
     name: 'LEM Building Surveying Ltd',
-    image: 'https://lembuildingsurveying.co.uk/logo.png',
-    logo: 'https://lembuildingsurveying.co.uk/logo.png',
     url: 'https://lembuildingsurveying.co.uk',
-    telephone: '+44-7378-732037',
-    address: {
-      '@type': 'PostalAddress',
-      streetAddress: 'Marlowe Avenue',
-      addressLocality: 'Deeside',
-      addressRegion: 'Flintshire',
-      postalCode: 'CH5 4HS',
-      addressCountry: 'UK',
-    },
-    geo: {
-      '@type': 'GeoCoordinates',
-      latitude: '53.1913',
-      longitude: '-2.8919',
-    },
-    sameAs: [
-      'https://www.facebook.com/share/1DZpcsZUUB/',
-      'https://www.linkedin.com/company/lem-building-surveying-ltd/',
-    ],
-    aggregateRating: { ...BUSINESS_AGGREGATE_RATING },
-  },
-  areaServed: {
-    '@type': 'Place',
-    name: 'Chester, Mold, Flintshire, Cheshire, North Wales',
   },
   offers: {
     '@type': 'Offer',
     url: pageUrl,
     priceCurrency: 'GBP',
+    price: '450',
+    availability: 'https://schema.org/InStock',
+    itemCondition: 'https://schema.org/NewCondition',
   },
+  aggregateRating: { ...BUSINESS_AGGREGATE_RATING },
+  review: GOOGLE_REVIEWS,
   url: pageUrl,
 };
 
@@ -69,7 +50,7 @@ const seo = {
   description: 'Most popular RICS survey. Photos + advice. Serving Chester, Mold, Flintshire. Get an instant quote online.',
   canonicalPath: '/level-2',
   fullTitle: true,
-  structuredData: [serviceSchema, faqSchema],
+  structuredData: [productSchema, faqSchema],
 };
 ---
 

--- a/src/pages/level-3.astro
+++ b/src/pages/level-3.astro
@@ -1,51 +1,32 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { BUSINESS_AGGREGATE_RATING } from '../utils/structuredData';
+import { GOOGLE_REVIEWS } from '../data/googleReviews';
 
 const pageUrl = 'https://lembuildingsurveying.co.uk/level-3';
 
-const serviceSchema = {
+const productSchema = {
   '@context': 'https://schema.org',
-  '@type': 'Service',
+  '@type': 'Product',
   name: 'RICS Level 3 Building Survey',
-  serviceType: 'RICS Level 3 Building Survey',
   description:
     'Comprehensive building survey for older or altered homes. Indepth advice by RICS surveyors. Instant estimate tool.',
-  provider: {
-    '@type': 'LocalBusiness',
+  sku: 'LEM-L3-SURVEY',
+  brand: {
+    '@type': 'Organization',
     name: 'LEM Building Surveying Ltd',
-    image: 'https://lembuildingsurveying.co.uk/logo.png',
-    logo: 'https://lembuildingsurveying.co.uk/logo.png',
     url: 'https://lembuildingsurveying.co.uk',
-    telephone: '+44-7378-732037',
-    address: {
-      '@type': 'PostalAddress',
-      streetAddress: 'Marlowe Avenue',
-      addressLocality: 'Deeside',
-      addressRegion: 'Flintshire',
-      postalCode: 'CH5 4HS',
-      addressCountry: 'UK',
-    },
-    geo: {
-      '@type': 'GeoCoordinates',
-      latitude: '53.1913',
-      longitude: '-2.8919',
-    },
-    sameAs: [
-      'https://www.facebook.com/share/1DZpcsZUUB/',
-      'https://www.linkedin.com/company/lem-building-surveying-ltd/',
-    ],
-    aggregateRating: { ...BUSINESS_AGGREGATE_RATING },
-  },
-  areaServed: {
-    '@type': 'Place',
-    name: 'Chester, Flintshire, Wrexham, Cheshire, North Wales',
   },
   offers: {
     '@type': 'Offer',
     url: pageUrl,
     priceCurrency: 'GBP',
+    price: '625',
+    availability: 'https://schema.org/InStock',
+    itemCondition: 'https://schema.org/NewCondition',
   },
+  aggregateRating: { ...BUSINESS_AGGREGATE_RATING },
+  review: GOOGLE_REVIEWS,
   url: pageUrl,
 };
 
@@ -70,7 +51,7 @@ const seo = {
     'Comprehensive building survey for older or altered homes. Indepth advice by RICS surveyors. Instant estimate tool.',
   canonicalPath: '/level-3',
   fullTitle: true,
-  structuredData: [serviceSchema, faqSchema],
+  structuredData: [productSchema, faqSchema],
 };
 ---
 

--- a/src/pages/services/damp-surveys.astro
+++ b/src/pages/services/damp-surveys.astro
@@ -1,5 +1,7 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
+import { BUSINESS_AGGREGATE_RATING } from "../../utils/structuredData";
+import { GOOGLE_REVIEWS } from "../../data/googleReviews";
 
 export const title =
   "Damp Surveys in North Wales & Cheshire | LEM Building Surveying";
@@ -31,42 +33,45 @@ const seo = {
   ],
 };
 
-const serviceSchema = {
+const productSchema = {
   "@context": "https://schema.org",
-  "@type": "Service",
-  name: "Professional Damp Surveys",
-  provider: { "@type": "Organization", name: "LEM Building Surveying Ltd" },
-  areaServed: ["Chester", "Wrexham", "Flintshire", "Connah's Quay"],
-  serviceType: "Professional damp survey",
+  "@type": "Product",
+  name: "Professional Damp Survey",
   description:
     "Professional damp surveys by RICS-accredited surveyors serving Chester, Wrexham, Flintshire and nearby towns.",
-  hasOfferCatalog: {
-    "@type": "OfferCatalog",
-    name: "Damp & Mould Investigation",
-    itemListElement: [
-      {
-        "@type": "Offer",
-        itemOffered: {
-          "@type": "Service",
-          name: "RICS-accredited damp survey and recommendations report",
-        },
-      },
-    ],
+  sku: "LEM-DAMP-SURVEY",
+  brand: {
+    "@type": "Organization",
+    name: "LEM Building Surveying Ltd",
+    url: "https://lembuildingsurveying.co.uk",
   },
+  offers: {
+    "@type": "Offer",
+    url: canonicalUrl,
+    priceCurrency: "GBP",
+    price: "495",
+    availability: "https://schema.org/InStock",
+    itemCondition: "https://schema.org/NewCondition",
+  },
+  aggregateRating: { ...BUSINESS_AGGREGATE_RATING },
+  review: GOOGLE_REVIEWS,
+  url: canonicalUrl,
 };
+
+const productSchemaJson = JSON.stringify(productSchema);
 ---
 
 <BaseLayout seo={seo}>
-  <article itemscope itemtype="https://schema.org/Service">
+  <article itemscope itemtype="https://schema.org/Product">
     <header>
       <h1 itemprop="name">Professional Damp Surveys</h1>
-      <p>
+      <p itemprop="description">
         <strong>Service areas:</strong> Chester, Wrexham, Flintshire, Connah's Quay and
         nearby towns.
       </p>
     </header>
 
-    <section itemprop="serviceType">
+    <section>
       <h2>Why Get a Damp Survey?</h2>
       <p>
         Whether you're buying a home or spotting suspicious patches in your current
@@ -81,7 +86,7 @@ const serviceSchema = {
       </ul>
     </section>
 
-    <section>
+    <section itemprop="description">
       <h2>What's Included in Our Survey</h2>
       <p>Our damp inspections include:</p>
       <ul>
@@ -132,7 +137,7 @@ const serviceSchema = {
     <script
       type="application/ld+json"
       is:inline
-      set:html={JSON.stringify(serviceSchema)}
+      set:html={productSchemaJson}
     />
   </article>
 </BaseLayout>


### PR DESCRIPTION
## Summary
- replace the service structured data on Level 1–3 and damp survey pages with Product schemas that surface pricing, brand, aggregate rating, and Google reviews
- share consistent Google review entries via a reusable data module and ensure JSON-LD is rendered server-side without inline `JSON.stringify`
- update the damp surveys service page microdata to reference the new Product schema

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d7cd8bc4088323890138a5456f92f8