### PR TITLE
Switch service structured data to Product schema

### DIFF
--- a/src/pages/independent-damp-surveys.astro
+++ b/src/pages/independent-damp-surveys.astro
@@ -35,6 +35,9 @@ const { seo: baseSeo, pageUrl } = createServiceSeo({
     ratingValue: 5,
     datePublished: "2024-05-22",
   },
+  sku: "INDEPENDENT-DAMP-SURVEY",
+  price: 275,
+  priceCurrency: "GBP",
 });
 
 const breadcrumbSchema = {

--- a/src/pages/rics-home-surveys.astro
+++ b/src/pages/rics-home-surveys.astro
@@ -55,6 +55,9 @@ const { seo: baseSeo, pageUrl } = createServiceSeo({
     ratingValue: 5,
     datePublished: '2024-07-08',
   },
+  sku: 'RICS-HOME-SURVEYS',
+  price: 350,
+  priceCurrency: 'GBP',
 });
 
 const breadcrumbSchema = {

--- a/src/pages/ventilation-assessments.astro
+++ b/src/pages/ventilation-assessments.astro
@@ -46,6 +46,9 @@ const { seo: baseSeo, pageUrl } = createServiceSeo({
     ratingValue: 5,
     datePublished: '2024-08-02',
   },
+  sku: 'VENTILATION-ASSESSMENT',
+  price: 250,
+  priceCurrency: 'GBP',
 });
 
 const breadcrumbSchema = {


### PR DESCRIPTION
## Summary
- replace the service JSON-LD builder with a Product schema that carries SKU, price, brand, offer and review metadata
- extend `createServiceSeo` to forward the new product pricing inputs while keeping FAQ structured data output
- update the RICS home survey, ventilation assessment and independent damp survey pages to provide SKU and GBP pricing values for the new schema

## Testing
- `npm run build` *(fails: missing cssnano dependency in tooling environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d7cd90d6508323b559d2d339a07a2a