### PR TITLE
Align service schema pricing with calculator

### DIFF
--- a/src/pages/damp-timber-surveys.astro
+++ b/src/pages/damp-timber-surveys.astro
@@ -2,6 +2,20 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { areaSelectorOptions } from '../data/areas';
 import { createServiceSeo } from '../utils/structuredData';
+import { SURVEYS } from '../lib/pricing';
+
+const getSurveyBaseFee = (id: typeof SURVEYS[number]['id']) => {
+  const survey = SURVEYS.find((item) => item.id === id);
+  if (!survey) {
+    throw new Error(`Missing survey pricing for ${id}`);
+  }
+
+  return survey.baseFee;
+};
+
+const timberAndDampBaseFee = getSurveyBaseFee('timber-and-damp');
+const dampSurveyBaseFee = getSurveyBaseFee('damp-survey');
+const dampAndMouldBaseFee = getSurveyBaseFee('damp-and-mould');
 
 const dampTimberFaqs = [
   {
@@ -51,6 +65,9 @@ const { seo: baseSeo, pageUrl } = createServiceSeo({
     ratingValue: 5,
     datePublished: '2024-07-04',
   },
+  // Bundle headline uses entry-level Damp Survey base fee.
+  price: dampSurveyBaseFee,
+  priceCurrency: 'GBP',
 });
 
 const breadcrumbSchema = {
@@ -78,9 +95,44 @@ const breadcrumbSchema = {
   ],
 };
 
+const specialistSurveySchemas = [
+  {
+    id: 'timber-and-damp',
+    name: 'Timber and Damp Investigation',
+    baseFee: timberAndDampBaseFee,
+  },
+  {
+    id: 'damp-survey',
+    name: 'Damp Survey',
+    baseFee: dampSurveyBaseFee,
+  },
+  {
+    id: 'damp-and-mould',
+    name: 'Damp and Mould Survey',
+    baseFee: dampAndMouldBaseFee,
+  },
+].map(({ id, name, baseFee }) => ({
+  '@context': 'https://schema.org',
+  '@type': 'Product',
+  '@id': `${pageUrl}#${id}`,
+  name,
+  sku: `LEM-${id.toUpperCase().replace(/[^A-Z0-9]+/g, '-')}`,
+  brand: {
+    '@type': 'Organization',
+    name: 'LEM Building Surveying Ltd',
+  },
+  offers: {
+    '@type': 'Offer',
+    url: pageUrl,
+    priceCurrency: 'GBP',
+    price: baseFee.toFixed(2),
+    availability: 'https://schema.org/InStock',
+  },
+}));
+
 const seo = {
   ...baseSeo,
-  structuredData: [...baseSeo.structuredData, breadcrumbSchema],
+  structuredData: [...baseSeo.structuredData, breadcrumbSchema, ...specialistSurveySchemas],
 };
 ---
 

--- a/src/pages/epc-with-floorplans.astro
+++ b/src/pages/epc-with-floorplans.astro
@@ -2,6 +2,9 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { areaSelectorOptions } from '../data/areas';
 import { createServiceSeo } from '../utils/structuredData';
+import { SURVEYS } from '../lib/pricing';
+
+const epcBaseFee = SURVEYS.find((survey) => survey.id === 'epc')?.baseFee ?? 0;
 
 const epcFaqs = [
   {
@@ -42,6 +45,8 @@ const { seo: baseSeo, pageUrl } = createServiceSeo({
     ratingValue: 5,
     datePublished: '2024-06-05',
   },
+  price: epcBaseFee,
+  priceCurrency: 'GBP',
 });
 
 const breadcrumbSchema = {

--- a/src/pages/independent-damp-surveys.astro
+++ b/src/pages/independent-damp-surveys.astro
@@ -1,6 +1,10 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { createServiceSeo } from "../utils/structuredData";
+import { SURVEYS } from "../lib/pricing";
+
+const dampSurveyBaseFee =
+  SURVEYS.find((survey) => survey.id === "damp-survey")?.baseFee ?? 0;
 
 const independentDampFaqs = [
   {
@@ -36,7 +40,7 @@ const { seo: baseSeo, pageUrl } = createServiceSeo({
     datePublished: "2024-05-22",
   },
   sku: "INDEPENDENT-DAMP-SURVEY",
-  price: 275,
+  price: dampSurveyBaseFee,
   priceCurrency: "GBP",
 });
 

--- a/src/pages/measured-surveys.astro
+++ b/src/pages/measured-surveys.astro
@@ -3,7 +3,11 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import ServiceContent from '../components/ServiceContent.astro';
 import { areaSelectorOptions } from '../data/areas';
 import { createServiceSeo } from '../utils/structuredData';
+import { SURVEYS } from '../lib/pricing';
 import { getEntry } from 'astro:content';
+
+const measuredSurveyBaseFee =
+  SURVEYS.find((survey) => survey.id === 'measured')?.baseFee ?? 0;
 
 const measuredSurveyFaqs = [
   {
@@ -38,6 +42,8 @@ const { seo: baseSeo, pageUrl } = createServiceSeo({
     ratingValue: 5,
     datePublished: '2024-04-10',
   },
+  price: measuredSurveyBaseFee,
+  priceCurrency: 'GBP',
 });
 
 const breadcrumbSchema = {

--- a/src/pages/rics-home-surveys.astro
+++ b/src/pages/rics-home-surveys.astro
@@ -4,6 +4,7 @@ import ServiceContent from '../components/ServiceContent.astro';
 import HomeInstantEstimate from '../components/HomeInstantEstimate';
 import { areaSelectorOptions } from '../data/areas';
 import { createServiceSeo } from '../utils/structuredData';
+import { SURVEY_FEE_BANDS } from '../lib/pricing';
 import { getEntry } from 'astro:content';
 
 const conversionSendToValue =
@@ -42,6 +43,9 @@ const ricsFaqs = [
 const description =
   'Compare Level 1, Level 2 and Level 3 RICS home surveys in Deeside, Chester and Flintshire with pricing guidance, quick booking and clear local reporting.';
 
+const entryLevelBand = SURVEY_FEE_BANDS[0];
+const representativeLevel2BaseFee = entryLevelBand.level2;
+
 const { seo: baseSeo, pageUrl } = createServiceSeo({
   title: 'Book Your RICS Home Survey — Fast | LEM Building Surveying',
   description,
@@ -56,7 +60,8 @@ const { seo: baseSeo, pageUrl } = createServiceSeo({
     datePublished: '2024-07-08',
   },
   sku: 'RICS-HOME-SURVEYS',
-  price: 350,
+  // Representative entry-level Level 2 fee for properties within £150k.
+  price: representativeLevel2BaseFee,
   priceCurrency: 'GBP',
 });
 

--- a/src/pages/ventilation-assessments.astro
+++ b/src/pages/ventilation-assessments.astro
@@ -2,6 +2,10 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { areaSelectorOptions } from '../data/areas';
 import { createServiceSeo } from '../utils/structuredData';
+import { SURVEYS } from '../lib/pricing';
+
+const ventilationBaseFee =
+  SURVEYS.find((survey) => survey.id === 'ventilation')?.baseFee ?? 0;
 
 const ventilationFaqs = [
   {
@@ -47,7 +51,7 @@ const { seo: baseSeo, pageUrl } = createServiceSeo({
     datePublished: '2024-08-02',
   },
   sku: 'VENTILATION-ASSESSMENT',
-  price: 250,
+  price: ventilationBaseFee,
   priceCurrency: 'GBP',
 });
 


### PR DESCRIPTION
## Summary
- import shared pricing constants into service pages that generate JSON-LD and replace hard-coded price literals
- expose bundle pricing for damp and timber services via individual product schemas so structured data reflects each base fee

## Testing
- npm run build *(fails: cssnano dependency is not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d7d605ea50832390cc2ee1a141b031